### PR TITLE
made `npm start` serve the functional tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,6 @@ From command prompt:
 * `npm install` This will install all dependent packages. (and will do very
 little if there are no changes)
 * `npm run build` This should not report any errors.
-* `cd packages/apps/functional-tests`
 * `npm start` This should print "INF: Multi-peer Adapter listening on..."
 * See also: [Using Visual Studio Code instead of command line](#Using-Visual-Studio-Code)
 

--- a/node/package.json
+++ b/node/package.json
@@ -28,7 +28,8 @@
     "build-docs": "lerna run build-docs",
     "lint": "lerna run lint",
     "lint-docs": "lerna run lint-docs",
-    "publish": "lerna publish"
+    "publish": "lerna publish",
+    "start": "node ./packages/functional-tests/"
   },
   "devDependencies": {
     "lerna": "3.4.2",


### PR DESCRIPTION
Asthis is the only MRE that the SDK repo contains, we should default to it from the root, so no need to change current directory before serving