### PR TITLE
LookAt updates

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,9 +21,7 @@
           ],
           "port": 9229,
           "cwd": "${workspaceFolder}/packages/functional-tests",
-          "internalConsoleOptions": "openOnSessionStart",
-          "autoAttachChildProcesses": true,
-          "outputCapture": "std"
+          "autoAttachChildProcesses": true
         },
     ]
 }

--- a/packages/functional-tests/src/app.ts
+++ b/packages/functional-tests/src/app.ts
@@ -21,6 +21,7 @@ import TextTest from './tests/text-test';
 export default class App {
     private activeTests: { [id: string]: Test } = {};
     private _rpc: MRERPC.ContextRPC;
+    private latestUser: MRESDK.User;
 
     public get context() { return this._context; }
     public get rpc() { return this._rpc; }
@@ -30,13 +31,13 @@ export default class App {
      */
     private testFactories: { [key: string]: () => Test } = {
         'gltf-animation-test': (): Test => new GltfAnimationTest(this, this.baseUrl),
-        'look-at-test': (): Test => new LookAtTest(this, this.baseUrl),
+        'look-at-test': (): Test => new LookAtTest(this, this.baseUrl, this.latestUser),
         'rigid-body-test': (): Test => new RigidBodyTest(this),
         'text-test': (): Test => new TextTest(this),
         'clock-sync-test': (): Test => new ClockSyncTest(this, this.baseUrl),
         'primitives-test': (): Test => new PrimitivesTest(this, this.baseUrl),
         'input-test': (): Test => new InputTest(this, this.baseUrl),
-        'asset-preload': (): Test => new AssetPreloadTest(this, this.baseUrl)
+        'asset-preload': (): Test => new AssetPreloadTest(this, this.baseUrl, this.latestUser)
     };
 
     constructor(private _context: MRESDK.Context, private params: MRESDK.ParameterSet, private baseUrl: string) {
@@ -51,6 +52,8 @@ export default class App {
 
     private userJoined = async (user: MRESDK.User) => {
         console.log(`user-joined: ${user.name}, ${user.id}`);
+
+        this.latestUser = user;
 
         let testName: string;
         if (Array.isArray(this.params.test) && this.params.test.length > 0) {

--- a/packages/functional-tests/src/tests/asset-preload.ts
+++ b/packages/functional-tests/src/tests/asset-preload.ts
@@ -11,7 +11,7 @@ import Test from './test';
 
 export default class AssetPreloadTest extends Test {
 
-    constructor(app: App, private baseUrl: string) {
+    constructor(app: App, private baseUrl: string, private user: MRESDK.User) {
         super(app);
     }
 
@@ -21,7 +21,6 @@ export default class AssetPreloadTest extends Test {
                 transform: {
                     position: { x: 0, y: 2, z: 0 }
                 },
-                lookAt: MRESDK.LookAtMode.LocalUserXY,
                 text: {
                     contents: 'Initialized',
                     height: 0.3,
@@ -29,6 +28,7 @@ export default class AssetPreloadTest extends Test {
                 }
             }
         });
+        label.lookAt(this.user, MRESDK.LookAtMode.TargetXY);
         await delay(1000);
 
         label.text.contents = 'Preloading asset';

--- a/packages/functional-tests/src/tests/look-at-test.ts
+++ b/packages/functional-tests/src/tests/look-at-test.ts
@@ -11,7 +11,7 @@ import Test from './test';
 
 export default class LookAtTest extends Test {
 
-    constructor(app: App, private baseUrl: string) {
+    constructor(app: App, private baseUrl: string, private user: MRESDK.User) {
         super(app);
     }
 
@@ -73,20 +73,23 @@ export default class LookAtTest extends Test {
         tester.startAnimation('circle');
 
         this.app.rpc.send('functional-test:trace-message', 'look-at-test', "LookAtMode.None");
-        tester.lookAt = MRESDK.LookAtMode.None;
+
+        tester.lookAt(null, MRESDK.LookAtMode.None);
         await delay(2000);
 
-        this.app.rpc.send('functional-test:trace-message', 'look-at-test', "LookAtMode.LocalUserXY");
-        tester.lookAt = MRESDK.LookAtMode.LocalUserXY;
+        this.app.rpc.send('functional-test:trace-message', 'look-at-test', "LookAtMode.TargetXY");
+        tester.lookAt(this.user, MRESDK.LookAtMode.TargetXY);
         await delay(8000);
 
-        this.app.rpc.send('functional-test:trace-message', 'look-at-test', "LookAtMode.LocalUserY");
-        tester.lookAt = MRESDK.LookAtMode.LocalUserY;
+        this.app.rpc.send('functional-test:trace-message', 'look-at-test', "LookAtMode.TargetY");
+        tester.lookAt(this.user, MRESDK.LookAtMode.TargetY);
         await delay(8000);
+
+        this.app.rpc.send('functional-test:trace-message', 'look-at-test', "LookAtMode.None");
+        tester.lookAt(null, MRESDK.LookAtMode.None);
+        await delay(2000);
 
         tester.stopAnimation('circle');
-        await delay(2000);
-
         destroyActors(tester);
 
         return true;

--- a/packages/gltf-gen/package-lock.json
+++ b/packages/gltf-gen/package-lock.json
@@ -73,9 +73,9 @@
 			"dev": true
 		},
 		"@types/shelljs": {
-			"version": "0.8.0",
-			"resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.8.0.tgz",
-			"integrity": "sha512-vs1hCC8RxLHRu2bwumNyYRNrU3o8BtZhLysH5A4I98iYmA2APl6R3uNQb5ihl+WiwH0xdC9LLO+vRrXLs/Kyxg==",
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.8.1.tgz",
+			"integrity": "sha512-1lQw+48BuVgp6c1+z8EMipp18IdnV2dLh6KQGwOm+kJy9nPjEkaqRKmwbDNEYf//EKBvKcwOC6V2cDrNxVoQeQ==",
 			"dev": true,
 			"requires": {
 				"@types/glob": "*",
@@ -678,9 +678,9 @@
 			}
 		},
 		"typedoc": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.12.0.tgz",
-			"integrity": "sha512-dsdlaYZ7Je8JC+jQ3j2Iroe4uyD0GhqzADNUVyBRgLuytQDP/g0dPkAw5PdM/4drnmmJjRzSWW97FkKo+ITqQg==",
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.13.0.tgz",
+			"integrity": "sha512-jQWtvPcV+0fiLZAXFEe70v5gqjDO6pJYJz4mlTtmGJeW2KRoIU/BEfktma6Uj8Xii7UakuZjbxFewl3UYOkU/w==",
 			"dev": true,
 			"requires": {
 				"@types/fs-extra": "^5.0.3",
@@ -699,7 +699,15 @@
 				"progress": "^2.0.0",
 				"shelljs": "^0.8.2",
 				"typedoc-default-themes": "^0.5.0",
-				"typescript": "3.0.x"
+				"typescript": "3.1.x"
+			},
+			"dependencies": {
+				"typescript": {
+					"version": "3.1.6",
+					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
+					"integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==",
+					"dev": true
+				}
 			}
 		},
 		"typedoc-default-themes": {

--- a/packages/gltf-gen/package.json
+++ b/packages/gltf-gen/package.json
@@ -41,7 +41,7 @@
     "gltf-typescript-generator": "^0.0.3",
     "gltf-validator": "^2.0.0-dev.2.5",
     "tslint": "5.11.0",
-    "typedoc": "^0.12.0",
+    "typedoc": "0.13.0",
     "typescript": "3.0.3"
   },
   "dependencies": {

--- a/packages/sdk/package-lock.json
+++ b/packages/sdk/package-lock.json
@@ -34,6 +34,56 @@
 			"integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA==",
 			"dev": true
 		},
+		"@types/fs-extra": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.4.tgz",
+			"integrity": "sha512-DsknoBvD8s+RFfSGjmERJ7ZOP1HI0UZRA3FSI+Zakhrc/Gy26YQsLI+m5V5DHxroHRJqCDLKJp7Hixn8zyaF7g==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
+		},
+		"@types/glob": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
+			"integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+			"dev": true,
+			"requires": {
+				"@types/events": "*",
+				"@types/minimatch": "*",
+				"@types/node": "*"
+			}
+		},
+		"@types/handlebars": {
+			"version": "4.0.39",
+			"resolved": "https://registry.npmjs.org/@types/handlebars/-/handlebars-4.0.39.tgz",
+			"integrity": "sha512-vjaS7Q0dVqFp85QhyPSZqDKnTTCemcSHNHFvDdalO1s0Ifz5KuE64jQD5xoUkfdWwF4WpqdJEl7LsWH8rzhKJA==",
+			"dev": true
+		},
+		"@types/highlight.js": {
+			"version": "9.12.3",
+			"resolved": "https://registry.npmjs.org/@types/highlight.js/-/highlight.js-9.12.3.tgz",
+			"integrity": "sha512-pGF/zvYOACZ/gLGWdQH8zSwteQS1epp68yRcVLJMgUck/MjEn/FBYmPub9pXT8C1e4a8YZfHo1CKyV8q1vKUnQ==",
+			"dev": true
+		},
+		"@types/lodash": {
+			"version": "4.14.119",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.119.tgz",
+			"integrity": "sha512-Z3TNyBL8Vd/M9D9Ms2S3LmFq2sSMzahodD6rCS9V2N44HUMINb75jNkSuwAx7eo2ufqTdfOdtGQpNbieUjPQmw==",
+			"dev": true
+		},
+		"@types/marked": {
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/@types/marked/-/marked-0.4.2.tgz",
+			"integrity": "sha512-cDB930/7MbzaGF6U3IwSQp6XBru8xWajF5PV2YZZeV8DyiliTuld11afVztGI9+yJZ29il5E+NpGA6ooV/Cjkg==",
+			"dev": true
+		},
+		"@types/minimatch": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+			"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+			"dev": true
+		},
 		"@types/node": {
 			"version": "10.12.0",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.0.tgz",
@@ -54,6 +104,16 @@
 				"@types/bunyan": "*",
 				"@types/node": "*",
 				"@types/spdy": "*"
+			}
+		},
+		"@types/shelljs": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.8.1.tgz",
+			"integrity": "sha512-1lQw+48BuVgp6c1+z8EMipp18IdnV2dLh6KQGwOm+kJy9nPjEkaqRKmwbDNEYf//EKBvKcwOC6V2cDrNxVoQeQ==",
+			"dev": true,
+			"requires": {
+				"@types/glob": "*",
+				"@types/node": "*"
 			}
 		},
 		"@types/spdy": {
@@ -117,6 +177,15 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
 			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+		},
+		"async": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+			"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+			"dev": true,
+			"requires": {
+				"lodash": "^4.17.10"
+			}
 		},
 		"async-limiter": {
 			"version": "1.0.0",
@@ -390,6 +459,17 @@
 			"resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
 			"integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg=="
 		},
+		"fs-extra": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+			"integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.2",
+				"jsonfile": "^4.0.0",
+				"universalify": "^0.1.0"
+			}
+		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -418,10 +498,28 @@
 				"path-is-absolute": "^1.0.0"
 			}
 		},
+		"graceful-fs": {
+			"version": "4.1.15",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+			"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+			"dev": true
+		},
 		"handle-thing": {
 			"version": "1.2.5",
 			"resolved": "http://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
 			"integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ="
+		},
+		"handlebars": {
+			"version": "4.0.12",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.12.tgz",
+			"integrity": "sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==",
+			"dev": true,
+			"requires": {
+				"async": "^2.5.0",
+				"optimist": "^0.6.1",
+				"source-map": "^0.6.1",
+				"uglify-js": "^3.1.4"
+			}
 		},
 		"has-ansi": {
 			"version": "2.0.0",
@@ -436,6 +534,12 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
 			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"dev": true
+		},
+		"highlight.js": {
+			"version": "9.13.1",
+			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.13.1.tgz",
+			"integrity": "sha512-Sc28JNQNDzaH6PORtRLMvif9RSn1mYuOoX3omVjnb0+HbpPygU2ALBI0R/wsiqCb4/fcp07Gdo8g+fhtFrQl6A==",
 			"dev": true
 		},
 		"hpack.js": {
@@ -478,6 +582,12 @@
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
 			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
 		},
+		"interpret": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+			"integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
+			"dev": true
+		},
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -509,6 +619,15 @@
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
 			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
 		},
+		"jsonfile": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
 		"jsprim": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -539,6 +658,12 @@
 				"yallist": "^3.0.2"
 			}
 		},
+		"marked": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-0.4.0.tgz",
+			"integrity": "sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw==",
+			"dev": true
+		},
 		"mime": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
@@ -560,8 +685,7 @@
 		"minimist": {
 			"version": "0.0.8",
 			"resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-			"optional": true
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
 		},
 		"mkdirp": {
 			"version": "0.5.1",
@@ -624,6 +748,16 @@
 				"wrappy": "1"
 			}
 		},
+		"optimist": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+			"dev": true,
+			"requires": {
+				"minimist": "~0.0.1",
+				"wordwrap": "~0.0.2"
+			}
+		},
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -644,6 +778,12 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
 			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+		},
+		"progress": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+			"dev": true
 		},
 		"pseudomap": {
 			"version": "1.0.2",
@@ -676,6 +816,24 @@
 				"safe-buffer": "~5.1.1",
 				"string_decoder": "~1.1.1",
 				"util-deprecate": "~1.0.1"
+			}
+		},
+		"rechoir": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+			"dev": true,
+			"requires": {
+				"resolve": "^1.1.6"
+			}
+		},
+		"resolve": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+			"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+			"dev": true,
+			"requires": {
+				"path-parse": "^1.0.5"
 			}
 		},
 		"restify": {
@@ -785,6 +943,23 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/semver-store/-/semver-store-0.3.0.tgz",
 			"integrity": "sha512-TcZvGMMy9vodEFSse30lWinkj+JgOBvPn8wRItpQRSayhc+4ssDs335uklkfvQQJgL/WvmHLVj4Ycv2s7QCQMg=="
+		},
+		"shelljs": {
+			"version": "0.8.3",
+			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
+			"integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
+			"dev": true,
+			"requires": {
+				"glob": "^7.0.0",
+				"interpret": "^1.0.0",
+				"rechoir": "^0.6.2"
+			}
+		},
+		"source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true
 		},
 		"spdy": {
 			"version": "3.4.7",
@@ -949,10 +1124,66 @@
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
 			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
 		},
+		"typedoc": {
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.13.0.tgz",
+			"integrity": "sha512-jQWtvPcV+0fiLZAXFEe70v5gqjDO6pJYJz4mlTtmGJeW2KRoIU/BEfktma6Uj8Xii7UakuZjbxFewl3UYOkU/w==",
+			"dev": true,
+			"requires": {
+				"@types/fs-extra": "^5.0.3",
+				"@types/handlebars": "^4.0.38",
+				"@types/highlight.js": "^9.12.3",
+				"@types/lodash": "^4.14.110",
+				"@types/marked": "^0.4.0",
+				"@types/minimatch": "3.0.3",
+				"@types/shelljs": "^0.8.0",
+				"fs-extra": "^7.0.0",
+				"handlebars": "^4.0.6",
+				"highlight.js": "^9.0.0",
+				"lodash": "^4.17.10",
+				"marked": "^0.4.0",
+				"minimatch": "^3.0.0",
+				"progress": "^2.0.0",
+				"shelljs": "^0.8.2",
+				"typedoc-default-themes": "^0.5.0",
+				"typescript": "3.1.x"
+			},
+			"dependencies": {
+				"typescript": {
+					"version": "3.1.6",
+					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
+					"integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==",
+					"dev": true
+				}
+			}
+		},
+		"typedoc-default-themes": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.5.0.tgz",
+			"integrity": "sha1-bcJDPnjti+qOiHo6zeLzF4W9Yic=",
+			"dev": true
+		},
 		"typescript": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.3.tgz",
 			"integrity": "sha512-kk80vLW9iGtjMnIv11qyxLqZm20UklzuR2tL0QAnDIygIUIemcZMxlMWudl9OOt76H3ntVzcTiddQ1/pAAJMYg==",
+			"dev": true
+		},
+		"uglify-js": {
+			"version": "3.4.9",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
+			"integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"commander": "~2.17.1",
+				"source-map": "~0.6.1"
+			}
+		},
+		"universalify": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
 			"dev": true
 		},
 		"util-deprecate": {
@@ -1005,6 +1236,12 @@
 			"requires": {
 				"minimalistic-assert": "^1.0.0"
 			}
+		},
+		"wordwrap": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+			"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+			"dev": true
 		},
 		"wrappy": {
 			"version": "1.0.2",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -41,6 +41,7 @@
     "@types/uuid": "^3.4.3",
     "@types/ws": "^6.0.1",
     "tslint": "5.11.0",
+    "typedoc": "0.13.0",
     "typescript": "3.0.3"
   },
   "dependencies": {

--- a/packages/sdk/src/types/internal/context.ts
+++ b/packages/sdk/src/types/internal/context.ts
@@ -18,6 +18,7 @@ import {
     Context,
     Light,
     LightLike,
+    LookAtMode,
     PrimitiveDefinition,
     RigidBody,
     RigidBodyLike,
@@ -46,6 +47,7 @@ import {
     EnableLight,
     EnableRigidBody,
     EnableText,
+    LookAt,
     ObjectSpawned,
     OperationResult,
     PauseAnimation,
@@ -422,6 +424,24 @@ export class InternalContext {
                 .catch((reason) => log.error('app', reason));
         } else {
             log.error('app', `Failed to reset animation ${animationName}. Actor ${actorId} not found`);
+        }
+    }
+
+    public lookAt(actorId: string, targetId: string, lookAtMode: LookAtMode) {
+        const actor = this.actorSet[actorId];
+        if (actor) {
+            actor.created().then(() => {
+                this.protocol.sendPayload({
+                    type: 'look-at',
+                    actorId,
+                    targetId,
+                    lookAtMode
+                } as LookAt);
+            }).catch((reason: any) => {
+                log.error('app', `Failed enable rigid body on actor ${actor.id}. ${(reason || '').toString()}`.trim());
+            });
+        } else {
+            log.error('app', `Failed lookAt. Actor ${actorId} not found`);
         }
     }
 

--- a/packages/sdk/src/types/lookatMode.ts
+++ b/packages/sdk/src/types/lookatMode.ts
@@ -14,12 +14,12 @@ export enum LookAtMode {
     None = 'None',
 
     /**
-     * Actor rotates around its Y axis to face the local user, offset by its rotation
+     * Actor rotates around its Y axis to face the target, offset by its rotation
      */
-    LocalUserY = 'LocalUserY',
+    TargetY = 'TargetY',
 
     /**
-     * Actor rotates around its X and Y axes to face the local user, offset by its rotation
+     * Actor rotates around its X and Y axes to face the target, offset by its rotation
      */
-    LocalUserXY = 'LocalUserXY'
+    TargetXY = 'TargetXY'
 }

--- a/packages/sdk/src/types/network/payloads/payloads.ts
+++ b/packages/sdk/src/types/network/payloads/payloads.ts
@@ -10,6 +10,7 @@ import {
     AnimationState,
     AnimationWrapMode,
 } from '../../..';
+import { LookAtMode } from '../../lookatMode';
 import { PrimitiveDefinition } from '../../primitiveTypes';
 import { ActorLike, ColliderType, LightLike, RigidBodyLike, TextLike, UserLike } from '../../runtime';
 import { ActionState, BehaviorType } from '../../runtime/behaviors';
@@ -444,4 +445,15 @@ export type ResumeAnimation = Payload & {
 export type SyncAnimations = Payload & {
     type: 'sync-animations';
     animationStates: AnimationState[];
+};
+
+/**
+ * @hidden
+ * App to engine. Instruct the actor to face another actor or user.
+ */
+export type LookAt = Payload & {
+    type: 'look-at';
+    actorId: string;
+    targetId: string;
+    lookAtMode: LookAtMode;
 };


### PR DESCRIPTION
This is the TypeScript side of the LookAt changes discussed on Teams. One change in here not discussed: The "preserve original rotation" feature was being problematic when the app itself was rotated, so I removed it for now.

LookAt is now invoked by calling a method on Actor, similar in spirit to `startAnimation`, etc. It can look at another Actor or User known to the app:
```ts
public lookAt(targetOrId: Actor | User | string, lookAtMode: LookAtMode);
```
