### PR TITLE
Log node and sdk versions at startup

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,7 +21,10 @@
           ],
           "port": 9229,
           "cwd": "${workspaceFolder}/packages/functional-tests",
-          "autoAttachChildProcesses": true
+          "autoAttachChildProcesses": true,
+          "console": "internalConsole",
+          "internalConsoleOptions": "openOnSessionStart",
+          "outputCapture": "std"
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,9 +21,7 @@
           ],
           "port": 9229,
           "cwd": "${workspaceFolder}/packages/functional-tests",
-          "internalConsoleOptions": "openOnSessionStart",
-          "autoAttachChildProcesses": true,
-          "outputCapture": "std"
+          "autoAttachChildProcesses": true
         },
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,6 +22,6 @@
           "port": 9229,
           "cwd": "${workspaceFolder}/packages/functional-tests",
           "autoAttachChildProcesses": true
-        },
+        }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,58 +7,138 @@
       "type": "npm",
       "script": "build",
       "path": "packages/",
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": false,
+        "panel": "shared",
+        "showReuseMessage": true,
+        "clear": true
+      },
       "problemMatcher": []
     },
     {
       "type": "npm",
       "script": "build",
       "path": "packages/sdk/",
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": false,
+        "panel": "shared",
+        "showReuseMessage": true,
+        "clear": true
+      },
       "problemMatcher": []
     },
     {
       "type": "npm",
       "script": "build",
       "path": "packages/sdk-azure/",
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": false,
+        "panel": "shared",
+        "showReuseMessage": true,
+        "clear": true
+      },
       "problemMatcher": []
     },
     {
       "type": "npm",
       "script": "build",
       "path": "packages/functional-tests/",
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": false,
+        "panel": "shared",
+        "showReuseMessage": true,
+        "clear": true
+      },
       "problemMatcher": []
     },
     {
       "type": "npm",
       "script": "build",
       "path": "packages/gltf-gen/",
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": false,
+        "panel": "shared",
+        "showReuseMessage": true,
+        "clear": true
+      },
       "problemMatcher": []
     },
     {
       "type": "npm",
       "script": "build",
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": false,
+        "panel": "shared",
+        "showReuseMessage": true,
+        "clear": true
+      },
       "problemMatcher": []
     },
     {
       "type": "npm",
       "script": "lint",
       "path": "packages/",
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": false,
+        "panel": "shared",
+        "showReuseMessage": true,
+        "clear": true
+      },
       "problemMatcher": []
     },
     {
       "type": "npm",
       "script": "lint",
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": false,
+        "panel": "shared",
+        "showReuseMessage": true,
+        "clear": true
+      },
       "problemMatcher": []
     },
     {
       "type": "npm",
       "script": "lint-docs",
       "path": "packages/",
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": false,
+        "panel": "shared",
+        "showReuseMessage": true,
+        "clear": true
+      },
       "problemMatcher": []
     },
     {
       "type": "npm",
       "script": "build-docs",
       "path": "packages/",
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": false,
+        "panel": "shared",
+        "showReuseMessage": true,
+        "clear": true
+      },
       "problemMatcher": []
     }
   ]

--- a/packages/sdk/src/webHost.ts
+++ b/packages/sdk/src/webHost.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { resolve as resolvePath } from 'path';
 import * as Restify from 'restify';
 import { Adapter, MultipeerAdapter } from '.';
 import { log } from './log';
@@ -25,7 +24,11 @@ export class WebHost {
     public constructor(
         options: { baseDir?: string, baseUrl?: string, port?: string | number } = {}
     ) {
-        this._baseDir = options.baseDir || process.env.BASE_DIR || resolvePath('./public');
+        const pjson = require('../package.json');
+        log.logToApp(`Node: ${process.version}`);
+        log.logToApp(`${pjson.name}: v${pjson.version}`);
+
+        this._baseDir = options.baseDir || process.env.BASE_DIR;
         this._baseUrl = options.baseUrl || process.env.BASE_URL;
 
         // Azure defines WEBSITE_HOSTNAME.
@@ -46,7 +49,9 @@ export class WebHost {
                 log.logToApp(`${server.name} listening on ${JSON.stringify(server.address())}`);
                 log.logToApp(`baseUrl: ${this.baseUrl}`);
                 log.logToApp(`baseDir: ${this.baseDir}`);
-                this.serveStaticFiles(server);
+                if (!!this.baseDir) {
+                    this.serveStaticFiles(server);
+                }
             })
             .catch(reason => log.error('app', `Failed to start HTTP server: ${reason}`));
     }


### PR DESCRIPTION
At startup, log Node and SDK versions to the console.

Startup log looks something like this now:
```
app Node: v8.12.0 +0ms
app @microsoft/mixed-reality-extension-sdk: v0.2.1 +2ms
app Multi-peer Adapter listening on {"address":"::","family":"IPv6","port":3901} +11ms
app baseUrl: http://127.0.0.1:3901 +1ms
app baseDir: D:\mixed-reality-extension-sdk\packages\functional-tests\public +0ms
```

Other changes:
- Don't try to infer `baseDir`. There's no reliable way to do this.
- Only serve static files if `baseDir` was provided.