### PR TITLE
enable lint on functional tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
     "bootstrap": "lerna bootstrap",
     "postinstall": "npm run bootstrap",
     "clean": "tsc --build --clean",
-    "build": "tslint -p ./packages/tsconfig.lint.json && tsc --build",
+    "build": "tsc --build && npm run lint",
     "build-docs": "lerna run build-docs",
-    "lint": "lerna run lint",
+    "lint": "tslint -p ./packages/tsconfig.lint.json",
     "lint-docs": "lerna run lint-docs",
     "publish": "lerna publish",
     "start": "node ./packages/functional-tests/"

--- a/packages/functional-tests/package-lock.json
+++ b/packages/functional-tests/package-lock.json
@@ -39,6 +39,27 @@
 				"@types/node": "*"
 			}
 		},
+		"ansi-regex": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+			"dev": true
+		},
+		"ansi-styles": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+			"dev": true
+		},
+		"argparse": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"dev": true,
+			"requires": {
+				"sprintf-js": "~1.0.2"
+			}
+		},
 		"asn1": {
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
@@ -52,11 +73,36 @@
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
 			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 		},
+		"babel-code-frame": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+			"dev": true,
+			"requires": {
+				"chalk": "^1.1.3",
+				"esutils": "^2.0.2",
+				"js-tokens": "^3.0.2"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				}
+			}
+		},
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-			"optional": true
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.2",
@@ -70,11 +116,16 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"optional": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
 			}
+		},
+		"builtin-modules": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+			"dev": true
 		},
 		"bunyan": {
 			"version": "1.8.12",
@@ -87,11 +138,62 @@
 				"safe-json-stringify": "~1"
 			}
 		},
+		"chalk": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+			"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"dev": true,
+			"requires": {
+				"color-name": "1.1.3"
+			}
+		},
+		"color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"dev": true
+		},
+		"commander": {
+			"version": "2.19.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+			"integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+			"dev": true
+		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-			"optional": true
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"core-util-is": {
 			"version": "1.0.2",
@@ -148,6 +250,12 @@
 			"resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
 			"integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw=="
 		},
+		"diff": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+			"dev": true
+		},
 		"dtrace-provider": {
 			"version": "0.8.7",
 			"resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.7.tgz",
@@ -170,6 +278,24 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz",
 			"integrity": "sha1-nGO20LJf8qiMOtvRjFthrMO5+qI="
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true
+		},
+		"esprima": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"dev": true
+		},
+		"esutils": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+			"dev": true
 		},
 		"ewma": {
 			"version": "2.0.1",
@@ -204,6 +330,12 @@
 			"resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
 			"integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg=="
 		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
+		},
 		"getpass": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
@@ -229,6 +361,21 @@
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
 			"integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ="
+		},
+		"has-ansi": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+			"dev": true,
+			"requires": {
+				"ansi-regex": "^2.0.0"
+			}
+		},
+		"has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"dev": true
 		},
 		"hpack.js": {
 			"version": "2.1.6",
@@ -260,7 +407,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"optional": true,
 			"requires": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -275,6 +421,22 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+		},
+		"js-tokens": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+			"dev": true
+		},
+		"js-yaml": {
+			"version": "3.12.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
+			"integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+			"dev": true,
+			"requires": {
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
+			}
 		},
 		"jsbn": {
 			"version": "0.1.1",
@@ -330,7 +492,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-			"optional": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
@@ -416,8 +577,13 @@
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"optional": true
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+		},
+		"path-parse": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+			"dev": true
 		},
 		"pidusage": {
 			"version": "1.2.0",
@@ -451,6 +617,15 @@
 				"safe-buffer": "~5.1.1",
 				"string_decoder": "~1.1.1",
 				"util-deprecate": "~1.0.1"
+			}
+		},
+		"resolve": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.9.0.tgz",
+			"integrity": "sha512-TZNye00tI67lwYvzxCxHGjwTNlUV70io54/Ed4j6PscB8xVfuBJpRenI/o6dVk0cY0PYTY27AgCoGGxRnYuItQ==",
+			"dev": true,
+			"requires": {
+				"path-parse": "^1.0.6"
 			}
 		},
 		"restify": {
@@ -564,6 +739,12 @@
 				"wbuf": "^1.7.2"
 			}
 		},
+		"sprintf-js": {
+			"version": "1.0.3",
+			"resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"dev": true
+		},
 		"sshpk": {
 			"version": "1.15.1",
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.1.tgz",
@@ -591,6 +772,72 @@
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"requires": {
 				"safe-buffer": "~5.1.0"
+			}
+		},
+		"strip-ansi": {
+			"version": "3.0.1",
+			"resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+			"dev": true,
+			"requires": {
+				"ansi-regex": "^2.0.0"
+			}
+		},
+		"supports-color": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+			"dev": true
+		},
+		"tslib": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+			"dev": true
+		},
+		"tslint": {
+			"version": "5.11.0",
+			"resolved": "https://registry.npmjs.org/tslint/-/tslint-5.11.0.tgz",
+			"integrity": "sha1-mPMMAurjzecAYgHkwzywi0hYHu0=",
+			"dev": true,
+			"requires": {
+				"babel-code-frame": "^6.22.0",
+				"builtin-modules": "^1.1.1",
+				"chalk": "^2.3.0",
+				"commander": "^2.12.1",
+				"diff": "^3.2.0",
+				"glob": "^7.1.1",
+				"js-yaml": "^3.7.0",
+				"minimatch": "^3.0.4",
+				"resolve": "^1.3.2",
+				"semver": "^5.3.0",
+				"tslib": "^1.8.0",
+				"tsutils": "^2.27.2"
+			},
+			"dependencies": {
+				"glob": {
+					"version": "7.1.3",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+					"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				}
+			}
+		},
+		"tsutils": {
+			"version": "2.29.0",
+			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
+			"integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+			"dev": true,
+			"requires": {
+				"tslib": "^1.8.1"
 			}
 		},
 		"tweetnacl": {

--- a/packages/functional-tests/package.json
+++ b/packages/functional-tests/package.json
@@ -12,13 +12,15 @@
   },
   "scripts": {
     "clean": "tsc --build --clean",
-    "build": "tsc --build",
+    "build": " tsc --build && npm run lint",
+    "lint": "tslint -p ./tsconfig.json -c tslint.json",
     "debug": "node --nolazy --inspect-brk=9229 .",
     "deploy": "@powershell ../../scripts/compress.ps1 -app 'functional-tests' && @powershell ../../scripts/deploy.ps1 -group 'mre-apps-linux' -name 'mre-functional-tests' -app 'functional-tests' && rm functional-tests.zip"
   },
   "devDependencies": {
     "@types/node": "^10.3.1",
     "@types/restify": "^7.2.0",
+    "tslint": "5.11.0",
     "typescript": "3.0.3"
   },
   "dependencies": {

--- a/packages/functional-tests/src/app.ts
+++ b/packages/functional-tests/src/app.ts
@@ -55,7 +55,6 @@ export default class App {
     private userJoined = async (user: MRESDK.User) => {
         console.log(`user-joined: ${user.name}, ${user.id}`);
 
-
         let testName: string;
         if (Array.isArray(this.params.test) && this.params.test.length > 0) {
             testName = this.params.test[0];
@@ -67,7 +66,7 @@ export default class App {
             this.rpc.send('functional-test:close-connection');
         } else {
             if (!this.firstUser) {
-                this.runFunctionalTestMenu();
+                const promise = this.runFunctionalTestMenu();
             }
             this.firstUser = user;
         }

--- a/packages/functional-tests/src/app.ts
+++ b/packages/functional-tests/src/app.ts
@@ -75,7 +75,6 @@ export default class App {
     private userLeft = (user: MRESDK.User) => {
         console.log(`user-left: ${user.name}, ${user.id}`);
     }
-
     private async startTest(testName: string,  user: MRESDK.User) {
         if (this.activeTests[testName]) {
             console.log(`Test already running: '${testName}'`);

--- a/packages/functional-tests/src/tests/clock-sync-test.ts
+++ b/packages/functional-tests/src/tests/clock-sync-test.ts
@@ -63,17 +63,19 @@ export default class ClockSyncTest extends Test {
 
         // Build animations.
         const yOffset = boxYPosition + lineHeight * 0.5;
-        this.buildDigitAnimation(meshHundredths.value, 4.25, yOffset, 1 / 100, 10, 10, lineHeight);
-        this.buildDigitAnimation(meshTenths.value, 3.25, yOffset, 1 / 10, 10, 10, lineHeight);
-        this.buildDigitAnimation(meshSeconds.value, 1.75, yOffset, 1, 10, 10, lineHeight);
-        this.buildDigitAnimation(mesh10Seconds.value, 0.75, yOffset, 10, 6, 6, lineHeight);
-        this.buildDigitAnimation(meshMinutes.value, -0.75, yOffset, 60, 10, 10, lineHeight);
-        this.buildDigitAnimation(mesh10Minutes.value, -1.75, yOffset, 10 * 60, 6, 6, lineHeight);
-        this.buildDigitAnimation(meshHours.value, -3.25, yOffset, 60 * 60, 24, 24, lineHeight);
-        this.buildDigitAnimation(mesh10Hours.value, -4.25, yOffset, 10 * 60 * 60, 3, 2.4, lineHeight);
+        const animations = [
+            this.buildDigitAnimation(meshHundredths.value, 4.25, yOffset, 1 / 100, 10, 10, lineHeight),
+            this.buildDigitAnimation(meshTenths.value, 3.25, yOffset, 1 / 10, 10, 10, lineHeight),
+            this.buildDigitAnimation(meshSeconds.value, 1.75, yOffset, 1, 10, 10, lineHeight),
+            this.buildDigitAnimation(mesh10Seconds.value, 0.75, yOffset, 10, 6, 6, lineHeight),
+            this.buildDigitAnimation(meshMinutes.value, -0.75, yOffset, 60, 10, 10, lineHeight),
+            this.buildDigitAnimation(mesh10Minutes.value, -1.75, yOffset, 10 * 60, 6, 6, lineHeight),
+            this.buildDigitAnimation(meshHours.value, -3.25, yOffset, 60 * 60, 24, 24, lineHeight),
+            this.buildDigitAnimation(mesh10Hours.value, -4.25, yOffset, 10 * 60 * 60, 3, 2.4, lineHeight)
+        ];
 
-        // Wait for all actors to instantiate on the host.
-        await Promise.all(actors);
+        // Wait for all actors and animations to instantiate on the host.
+        await Promise.all([actors, animations]);
 
         // Start the animations.
         actors.forEach(actor => actor.value.startAnimation('anim'));

--- a/packages/functional-tests/src/tests/input-test.ts
+++ b/packages/functional-tests/src/tests/input-test.ts
@@ -79,7 +79,7 @@ export default class InputTest extends Test {
                 }
             }
         });
-        actor.value.createAnimation({
+        const moveAnimation = actor.value.createAnimation({
             animationName: 'animmove',
             wrapMode: AnimationWrapMode.Once,
             events: [],
@@ -104,7 +104,7 @@ export default class InputTest extends Test {
                 }
             }
         });
-        actor.value.createAnimation({
+        const turnAnimation = actor.value.createAnimation({
             animationName: 'animturn',
             wrapMode: AnimationWrapMode.Once,
             events: [],
@@ -129,14 +129,14 @@ export default class InputTest extends Test {
                 }
             }
         });
-        actor.value.createAnimation({
+        const scaleAnimation = actor.value.createAnimation({
             animationName: 'animscale',
             wrapMode: AnimationWrapMode.Once,
             events: [],
             keyframes: keyframes3
 
         });
-
+        await Promise.all([moveAnimation, turnAnimation, scaleAnimation]);
         const buttonBehavior = actor.value.setBehavior(MRESDK.ButtonBehavior);
         console.log(`Added event.`);
 

--- a/packages/functional-tests/src/tests/look-at-test.ts
+++ b/packages/functional-tests/src/tests/look-at-test.ts
@@ -27,7 +27,7 @@ export default class LookAtTest extends Test {
         const tester = await MRESDK.Actor.CreateFromGLTF(this.app.context, {
             resourceUrl: `${this.baseUrl}/monkey.glb`
         });
-        tester.createAnimation({
+        await tester.createAnimation({
             animationName: 'circle',
             wrapMode: MRESDK.AnimationWrapMode.Loop,
             events: [],

--- a/packages/functional-tests/src/tests/text-test.ts
+++ b/packages/functional-tests/src/tests/text-test.ts
@@ -9,7 +9,7 @@ import delay from '../utils/delay';
 import destroyActors from '../utils/destroyActors';
 import Test from './test';
 
-const Options = {
+const options = {
     enabled: [true, false],
     contents: ["changing", "content"],
     ppl: [10, 20, 50],
@@ -117,36 +117,36 @@ export default class TextTest extends Test {
     }
 
     private cycleOptions(): void {
-        this.enabled.text.enabled = Options.enabled[
-            (Options.enabled.indexOf(this.enabled.text.enabled) + 1) % Options.enabled.length
+        this.enabled.text.enabled = options.enabled[
+            (options.enabled.indexOf(this.enabled.text.enabled) + 1) % options.enabled.length
         ];
 
-        this.contents.text.contents = Options.contents[
-            (Options.contents.indexOf(this.contents.text.contents) + 1) % Options.contents.length
+        this.contents.text.contents = options.contents[
+            (options.contents.indexOf(this.contents.text.contents) + 1) % options.contents.length
         ];
 
-        this.ppl.text.pixelsPerLine = Options.ppl[
-            (Options.ppl.indexOf(this.ppl.text.pixelsPerLine) + 1) % Options.ppl.length
+        this.ppl.text.pixelsPerLine = options.ppl[
+            (options.ppl.indexOf(this.ppl.text.pixelsPerLine) + 1) % options.ppl.length
         ];
 
-        this.height.text.height = Options.height[
-            (Options.height.indexOf(this.height.text.height) + 1) % Options.height.length
+        this.height.text.height = options.height[
+            (options.height.indexOf(this.height.text.height) + 1) % options.height.length
         ];
 
-        this.anchor.text.anchor = Options.anchor[
-            (Options.anchor.indexOf(this.anchor.text.anchor) + 1) % Options.anchor.length
+        this.anchor.text.anchor = options.anchor[
+            (options.anchor.indexOf(this.anchor.text.anchor) + 1) % options.anchor.length
         ];
 
-        this.justify.text.justify = Options.justify[
-            (Options.justify.indexOf(this.justify.text.justify) + 1) % Options.justify.length
+        this.justify.text.justify = options.justify[
+            (options.justify.indexOf(this.justify.text.justify) + 1) % options.justify.length
         ];
 
-        this.font.text.font = Options.font[
-            (Options.font.indexOf(this.font.text.font) + 1) % Options.font.length
+        this.font.text.font = options.font[
+            (options.font.indexOf(this.font.text.font) + 1) % options.font.length
         ];
 
-        this.color.text.color = Options.color[
-            (Options.color.findIndex(c => c.equals(this.color.text.color)) + 1) % Options.color.length
+        this.color.text.color = options.color[
+            (options.color.findIndex(c => c.equals(this.color.text.color)) + 1) % options.color.length
         ];
     }
 

--- a/packages/gltf-gen/package.json
+++ b/packages/gltf-gen/package.json
@@ -29,7 +29,7 @@
     "update-schema": "gltf-typescript-generator src/gen/gltf.ts https://rawgit.com/KhronosGroup/glTF/master/specification/2.0/schema/glTF.schema.json",
     "test": "npm run build && node built/tests/index.js",
     "clean": "tsc --build --clean",
-    "build": "npm run lint && tsc --build",
+    "build": "tsc --build && npm run lint",
     "build-docs": "typedoc --externalPattern \"**/node_modules/**\" --excludeExternals --excludeNotExported --excludeProtected --excludePrivate --hideGenerator --mode file --name \"glTF Generator\" --readme none --out ../../docs/gltf-gen ./src",
     "lint": "tslint -p ./tsconfig.json -c ../tslint.json",
     "lint-docs": "tslint -p ./tsconfig.json -c ../tslint.docs.json",

--- a/packages/sdk-azure/package.json
+++ b/packages/sdk-azure/package.json
@@ -26,7 +26,7 @@
   },
   "scripts": {
     "clean": "tsc --build --clean",
-    "build": "npm run lint && tsc --build",
+    "build": "tsc --build && npm run lint",
     "lint": "tslint -p ./tsconfig.json -c ../tslint.json",
     "prepublishOnly": "tsc --build"
   },

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "clean": "tsc --build --clean",
-    "build": "npm run lint && tsc --build",
+    "build": "tsc --build && npm run lint",
     "build-docs": "typedoc --externalPattern \"**/node_modules/**\" --excludeExternals --excludeNotExported --excludeProtected --excludePrivate --hideGenerator --mode file --name \"Mixed Reality Extension SDK\" --readme none --out ../../docs ./src",
     "lint": "tslint -p ./tsconfig.json -c ../tslint.json",
     "lint-docs": "tslint -p ./tsconfig.json -c ../tslint.docs.json",

--- a/packages/tsconfig.lint.json
+++ b/packages/tsconfig.lint.json
@@ -3,6 +3,7 @@
   "include": [
     "gltf-gen/src/**/*",
     "sdk/src/**/*",
-    "sdk-azure/src/**/*"
+    "sdk-azure/src/**/*",
+    "functional-tests/src/**/*"
   ]
 }


### PR DESCRIPTION
lint was disabled on functional test framework - this enables it, and makes sure we build each package before linting it, so we don't worry about lint errors on non-compiling code.