### PR TITLE
changes needed to deploy functional tests to openode

### DIFF
--- a/DEPLOYING.md
+++ b/DEPLOYING.md
@@ -135,6 +135,9 @@ Once your deployment succeeds, you're ready to connect from AltspaceVR! For inst
 on instantiating your app within AltspaceVR, checkout the [sample repo's README.md](
 https://github.com/Microsoft/mixed-reality-extension-sdk-samples/blob/master/README.md)
 
+If you want to re-deploy, you should use `openode stop` before calling `openode deploy`, otherwise the deploy will 
+fail. If a deploy fails, you can just call `openode deploy` again.
+
 ### Other Cloud Platforms
 
 Have a hosting service recommendation? Please add it to this doc and submit a PR!

--- a/packages/functional-tests/package.json
+++ b/packages/functional-tests/package.json
@@ -14,6 +14,7 @@
     "clean": "tsc --build --clean",
     "build": " tsc --build && npm run lint",
     "lint": "tslint -p ./tsconfig.json -c tslint.json",
+    "start": "node .",
     "debug": "node --nolazy --inspect-brk=9229 .",
     "deploy": "@powershell ../../scripts/compress.ps1 -app 'functional-tests' && @powershell ../../scripts/deploy.ps1 -group 'mre-apps-linux' -name 'mre-functional-tests' -app 'functional-tests' && rm functional-tests.zip"
   },
@@ -25,6 +26,7 @@
   },
   "dependencies": {
     "@microsoft/mixed-reality-extension-sdk": "^0.2.1",
+    "tslib": "1.9.3",
     "restify": "^7.2.0"
   }
 }


### PR DESCRIPTION
This is what I needed to changed for the openode.io deploy to just work for functional tests.

I couldn't explain why tslib is needed and our local builds don't complain about it, so I'm adding in the reference for now and an issue to track it whenever we need to debug it