### PR TITLE
Soren/exclude openode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -331,3 +331,4 @@ node_modules
 built
 npm-debug.log
 lerna-debug.log
+.openode


### PR DESCRIPTION
to stop accidental check-ins of .openode config files