### PR TITLE
Respect proxy/forwarder headers when determining the connection's source

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -47,6 +47,7 @@
     "@types/node": "^10.3.1",
     "debug": "^4.1.0",
     "deepmerge": "^2.1.1",
+    "forwarded-for": "^1.0.1",
     "query-string": "^6.2.0",
     "restify": "^7.2.0",
     "uuid": "^3.2.1",

--- a/packages/sdk/src/adapters/multipeer/adapter.ts
+++ b/packages/sdk/src/adapters/multipeer/adapter.ts
@@ -16,6 +16,9 @@ import { log } from './../../log';
 import { Client } from './client';
 import { Session } from './session';
 
+// tslint:disable-next-line:no-var-requires
+const forwarded = require('forwarded-for');
+
 /**
  * Multi-peer adapter options
  */
@@ -120,7 +123,10 @@ export class MultipeerAdapter extends Adapter {
             // Get the session for the sessionId
             const session = await this.getOrCreateSession(sessionId, params);
 
-            const conn = new WebSocket(ws, request.socket.remoteAddress);
+            // Get the client's IP address rather than the last proxy connecting to you
+            const address = forwarded(request, request.headers);
+
+            const conn = new WebSocket(ws, address.ip);
 
             // Instantiate a client for this connection
             const client = new Client(conn);


### PR DESCRIPTION
Currently, the remote address passed to the client's user.properties.remoteAddress is just the address of the last hop connecting to the MRE.

This fails whenever a proxy forwarded this request, e.g. Heroku's load balancers - the IP address shown would be the outgoing interface of the load balancer.

This change includes 'forwarded-for' which scans the HTTP headers for 'well-known' forwarder header lines like 'x-forwarded-for' and adjusts the IP address to be passed on accordingly. Without a proxy inbetween, forwarded-for would take the original remoteAddress of the request.