### PR TITLE
[SDK] Protection against undefined options

### DIFF
--- a/packages/sdk/src/types/internal/context.ts
+++ b/packages/sdk/src/types/internal/context.ts
@@ -139,6 +139,7 @@ export class InternalContext {
         actor?: Partial<ActorLike>,
         subscriptions?: SubscriptionType[]
     }): ForwardPromise<Actor> {
+        options = { ...options };
         options = {
             subscriptions: [],
             ...options,
@@ -161,6 +162,7 @@ export class InternalContext {
         actor?: Partial<ActorLike>,
         subscriptions?: SubscriptionType[]
     }): ForwardPromise<Actor> {
+        options = { ...options };
         options = {
             subscriptions: [],
             colliderType: 'none',
@@ -182,6 +184,7 @@ export class InternalContext {
         actor?: Partial<ActorLike>,
         subscriptions?: SubscriptionType[]
     }): ForwardPromise<Actor> {
+        options = { ...options };
         options = {
             subscriptions: [],
             ...options,
@@ -203,12 +206,10 @@ export class InternalContext {
         actor?: Partial<ActorLike>,
         subscriptions?: SubscriptionType[]
     }): ForwardPromise<Actor> {
+        options = { ...options };
         options = {
             subscriptions: [],
             addCollider: false,
-            ...options
-        };
-        options = {
             ...options,
             actor: {
                 ...options.actor,
@@ -227,6 +228,7 @@ export class InternalContext {
         actor?: Partial<ActorLike>,
         subscriptions?: SubscriptionType[]
     }): ForwardPromise<Actor> {
+        options = { ...options };
         options = {
             subscriptions: [],
             ...options,

--- a/packages/sdk/src/types/runtime/actor.ts
+++ b/packages/sdk/src/types/runtime/actor.ts
@@ -137,7 +137,7 @@ export class Actor implements ActorLike {
      * @param context The SDK context object.
      * @param options Creation parameters and actor characteristics.
      */
-    public static CreateEmpty(context: Context, options: {
+    public static CreateEmpty(context: Context, options?: {
         actor?: Partial<ActorLike>,
         subscriptions?: SubscriptionType[]
     }): ForwardPromise<Actor> {


### PR DESCRIPTION
Also make `options` parameter to CreateEmpty optional, since all its members are optional.