### PR TITLE
Rename CreateFromGLTF -> CreateFromGltf

### DIFF
--- a/packages/functional-tests/src/tests/gltf-animation-test.ts
+++ b/packages/functional-tests/src/tests/gltf-animation-test.ts
@@ -24,7 +24,7 @@ export default class GltfAnimationTest extends Test {
     }
 
     public async runGltfAnimationTest(): Promise<boolean> {
-        const tester = await MRESDK.Actor.CreateFromGLTF(this.app.context, {
+        const tester = await MRESDK.Actor.CreateFromGltf(this.app.context, {
             // tslint:disable-next-line:max-line-length
             resourceUrl: `https://github.com/KhronosGroup/glTF-Sample-Models/raw/master/2.0/CesiumMan/glTF-Binary/CesiumMan.glb`,
             actor: {

--- a/packages/functional-tests/src/tests/gltf-concurrency-test.ts
+++ b/packages/functional-tests/src/tests/gltf-concurrency-test.ts
@@ -16,7 +16,7 @@ export default class GltfConcurrencyTest extends Test {
     }
 
     public async run(): Promise<boolean> {
-        const runnerPromise = MRESDK.Actor.CreateFromGLTF(this.app.context, {
+        const runnerPromise = MRESDK.Actor.CreateFromGltf(this.app.context, {
             // tslint:disable-next-line:max-line-length
             resourceUrl: `https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/CesiumMan/glTF-Binary/CesiumMan.glb`,
             actor: {
@@ -26,7 +26,7 @@ export default class GltfConcurrencyTest extends Test {
             }
         });
 
-        const gearboxPromise = MRESDK.Actor.CreateFromGLTF(this.app.context, {
+        const gearboxPromise = MRESDK.Actor.CreateFromGltf(this.app.context, {
             // tslint:disable-next-line:max-line-length
             resourceUrl: 'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/GearboxAssy/glTF/GearboxAssy.gltf'
         });

--- a/packages/functional-tests/src/tests/gltf-gen-test.ts
+++ b/packages/functional-tests/src/tests/gltf-gen-test.ts
@@ -38,7 +38,7 @@ export default class GltfGenTest extends Test {
             })]
         })]);
 
-        const sphere = await MRE.Actor.CreateFromGLTF(this.app.context, {
+        const sphere = await MRE.Actor.CreateFromGltf(this.app.context, {
             resourceUrl: Server.registerStaticBuffer('sphere.glb', gltfFactory.generateGLTF())
         });
 

--- a/packages/functional-tests/src/tests/input-test.ts
+++ b/packages/functional-tests/src/tests/input-test.ts
@@ -50,7 +50,7 @@ export default class InputTest extends Test {
         text.text.contents = "Please Hover";
 
         // Load a glTF model
-        const modelPromise = Actor.CreateFromGLTF(this.app.context, {
+        const modelPromise = Actor.CreateFromGltf(this.app.context, {
             // at the given URL
             resourceUrl: `${this.baseUrl}/monkey.glb`,
             // and spawn box colliders around the meshes.

--- a/packages/functional-tests/src/tests/look-at-test.ts
+++ b/packages/functional-tests/src/tests/look-at-test.ts
@@ -24,7 +24,7 @@ export default class LookAtTest extends Test {
     }
 
     public async runLookAtTest(): Promise<boolean> {
-        const tester = await MRESDK.Actor.CreateFromGLTF(this.app.context, {
+        const tester = await MRESDK.Actor.CreateFromGltf(this.app.context, {
             resourceUrl: `${this.baseUrl}/monkey.glb`
         });
         await tester.createAnimation({

--- a/packages/functional-tests/tslint.json
+++ b/packages/functional-tests/tslint.json
@@ -2,6 +2,7 @@
     "extends": "../tslint.json",
     "rules": {
         "no-console": false,
-        "variable-name": false
+        "variable-name": false,
+        "deprecation": true
     }
 }

--- a/packages/sdk/src/adapters/multipeer/session.ts
+++ b/packages/sdk/src/adapters/multipeer/session.ts
@@ -296,8 +296,8 @@ export class Session extends EventEmitter {
 
     /** @private */
     public 'app-preprocess-create-from-gltf' = (
-        payload: Payloads.CreateFromGLTF,
-        message: MRESDK.Message<Payloads.CreateFromGLTF>) => {
+        payload: Payloads.CreateFromGltf,
+        message: MRESDK.Message<Payloads.CreateFromGltf>) => {
         this.createActor(payload, message);
         return payload;
     }

--- a/packages/sdk/src/types/internal/context.ts
+++ b/packages/sdk/src/types/internal/context.ts
@@ -39,7 +39,7 @@ import {
     CreateAnimation,
     CreateColliderType,
     CreateEmpty,
-    CreateFromGLTF,
+    CreateFromGltf,
     CreateFromLibrary,
     CreateFromPrefab,
     CreatePrimitive,
@@ -155,7 +155,7 @@ export class InternalContext {
         return this.createActorFromPayload(payload);
     }
 
-    public CreateFromGLTF(options: {
+    public CreateFromGltf(options: {
         resourceUrl: string,
         assetName?: string,
         colliderType?: CreateColliderType,
@@ -175,7 +175,7 @@ export class InternalContext {
         const payload = {
             ...options,
             type: 'create-from-gltf'
-        } as CreateFromGLTF;
+        } as CreateFromGltf;
         return this.createActorFromPayload(payload);
     }
 

--- a/packages/sdk/src/types/network/payloads/payloads.ts
+++ b/packages/sdk/src/types/network/payloads/payloads.ts
@@ -195,7 +195,7 @@ export type CreateFromLibrary = CreateActorCommon & {
  * App to engine. Request for engine to load a game object from a glTF file.
  * Response is an ObjectSpawned payload.
  */
-export type CreateFromGLTF = CreateActorCommon & {
+export type CreateFromGltf = CreateActorCommon & {
     type: 'create-from-gltf';
     resourceUrl: string;
     assetName: string;

--- a/packages/sdk/src/types/runtime/actor.ts
+++ b/packages/sdk/src/types/runtime/actor.ts
@@ -149,6 +149,20 @@ export class Actor implements ActorLike {
      * @param context The SDK context object.
      * @param options Creation parameters and actor characteristics.
      */
+    public static CreateFromGltf(context: Context, options: {
+        resourceUrl: string,
+        assetName?: string,
+        colliderType?: CreateColliderType,
+        actor?: Partial<ActorLike>,
+        subscriptions?: SubscriptionType[]
+    }): ForwardPromise<Actor> {
+        return context.internal.CreateFromGltf(options);
+    }
+
+    /**
+     * @deprecated
+     * Use CreateFromGltf instead.
+     */
     public static CreateFromGLTF(context: Context, options: {
         resourceUrl: string,
         assetName?: string,
@@ -156,7 +170,7 @@ export class Actor implements ActorLike {
         actor?: Partial<ActorLike>,
         subscriptions?: SubscriptionType[]
     }): ForwardPromise<Actor> {
-        return context.internal.CreateFromGLTF(options);
+        return context.internal.CreateFromGltf(options);
     }
 
     /**


### PR DESCRIPTION
Renamed for naming consistency with AssetManager.loadGltf and elsewhere. For backward compatibility the old call is deprecated rather than deleted.
