### PR TITLE
[SDK] Asset mutability

### DIFF
--- a/packages/functional-tests/src/app.ts
+++ b/packages/functional-tests/src/app.ts
@@ -14,6 +14,7 @@ import InputTest from './tests/input-test';
 import InterpolationTest from './tests/interpolation-test';
 import LibraryTest from './tests/library-test';
 import LookAtTest from './tests/look-at-test';
+import MutableAssetTest from './tests/mutable-asset-test';
 import PrimitivesTest from './tests/primitives-test';
 import RigidBodyTest from './tests/rigid-body-test';
 import Test from './tests/test';
@@ -46,6 +47,7 @@ export default class App {
         'input-test': (): Test => new InputTest(this, this.baseUrl),
         'library-test': (): Test => new LibraryTest(this, this.baseUrl),
         'look-at-test': (user: MRESDK.User): Test => new LookAtTest(this, this.baseUrl, user),
+        'mutable-asset-test': (user: MRESDK.User): Test => new MutableAssetTest(this, this.baseUrl, user),
         'primitives-test': (): Test => new PrimitivesTest(this, this.baseUrl),
         'rigid-body-test': (): Test => new RigidBodyTest(this),
         'text-test': (): Test => new TextTest(this),

--- a/packages/functional-tests/src/tests/asset-preload-test.ts
+++ b/packages/functional-tests/src/tests/asset-preload-test.ts
@@ -38,8 +38,8 @@ export default class AssetPreloadTest extends Test {
 
         label.text.contents = 'Preloading assets';
         const [prefabs, mats] = await Promise.all([
-            this.app.context.assets.loadGltf('monkey', this.baseUrl + '/monkey.glb'),
-            this.app.context.assets.loadGltf('uvgrid', this.generateMaterial())
+            this.app.context.assetManager.loadGltf('monkey', this.baseUrl + '/monkey.glb'),
+            this.app.context.assetManager.loadGltf('uvgrid', this.generateMaterial())
         ]);
         label.text.contents = `Assets preloaded:
 ${prefabs.prefabs.count + mats.prefabs.count} prefabs, ${prefabs.materials.count + mats.materials.count} materials`;

--- a/packages/functional-tests/src/tests/gltf-concurrency-test.ts
+++ b/packages/functional-tests/src/tests/gltf-concurrency-test.ts
@@ -31,7 +31,7 @@ export default class GltfConcurrencyTest extends Test {
             resourceUrl: 'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/GearboxAssy/glTF/GearboxAssy.gltf'
         });
 
-        const bottlePromise = this.app.context.assets.loadGltf('bottle',
+        const bottlePromise = this.app.context.assetManager.loadGltf('bottle',
             // tslint:disable-next-line:max-line-length
             'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/WaterBottle/glTF/WaterBottle.gltf');
 

--- a/packages/functional-tests/src/tests/mutable-asset-test.ts
+++ b/packages/functional-tests/src/tests/mutable-asset-test.ts
@@ -1,0 +1,63 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import * as MRESDK from '@microsoft/mixed-reality-extension-sdk';
+import App from '../app';
+import delay from '../utils/delay';
+import destroyActors from '../utils/destroyActors';
+import Test from './test';
+
+export default class MutableAssetTest extends Test {
+
+    constructor(app: App, private baseUrl: string, private user: MRESDK.User) {
+        super(app);
+    }
+
+    public async run(): Promise<boolean> {
+
+        const assets = await this.app.context.assetManager.loadGltf(
+            'assets', `${this.baseUrl}/monkey.glb`);
+
+        const monkey = MRESDK.Actor.CreateFromPrefab(this.app.context, {
+            prefabId: assets.prefabs.byIndex(0).id,
+            actor: {
+                name: 'monkey',
+                transform: {
+                    position: { x: 0, y: 1, z: 0 }
+                }
+            }
+        }).value;
+
+        const label = MRESDK.Actor.CreateEmpty(this.app.context, {
+            actor: {
+                name: 'label',
+                transform: {
+                    position: { x: 0, y: 2, z: 0 }
+                },
+                text: {
+                    contents: 'Original (pink)'
+                }
+            }
+        }).value;
+        label.lookAt(this.user, MRESDK.LookAtMode.TargetY);
+
+        await delay(3000);
+
+        const material = assets.materials.byIndex(0);
+        const origColor = material.color.clone();
+        material.color.set(0, 1, 0, 1);
+        label.text.contents = 'Green';
+
+        await delay(3000);
+
+        material.color.copyFrom(origColor);
+        label.text.contents = 'Back to original';
+
+        await delay(3000);
+
+        destroyActors([monkey, label]);
+        return true;
+    }
+}

--- a/packages/sdk/src/types/internal/actor.ts
+++ b/packages/sdk/src/types/internal/actor.ts
@@ -6,11 +6,12 @@
 import { ActionEvent, Actor, ActorLike, Behavior, CollisionData, SetAnimationStateOptions } from '../..';
 import { ExportedPromise } from '../../utils/exportedPromise';
 import { CollisionEventType } from '../network/payloads';
+import { InternalPatchable } from '../patchable';
 
 /**
  * @hidden
  */
-export class InternalActor {
+export class InternalActor implements InternalPatchable<ActorLike> {
     public observing = true;
     public patch: ActorLike;
     public behavior: Behavior;

--- a/packages/sdk/src/types/internal/asset.ts
+++ b/packages/sdk/src/types/internal/asset.ts
@@ -3,22 +3,22 @@
  * Licensed under the MIT License.
  */
 
-import { AssetLike, Material, MaterialLike } from '../..';
+import { Asset, AssetLike } from '../..';
 import { InternalPatchable } from '../patchable';
 
 /**
  * @hidden
  */
-export class InternalMaterial implements InternalPatchable<AssetLike> {
+export class InternalAsset implements InternalPatchable<AssetLike> {
     public observing = true;
     public patch: AssetLike;
 
-    public constructor(public material: Material) { }
+    public constructor(public asset: Asset) { }
 
     public getPatchAndReset(): AssetLike {
         const patch = this.patch;
         if (patch) {
-            patch.id = this.material.id;
+            patch.id = this.asset.id;
             delete this.patch;
         }
         return patch;

--- a/packages/sdk/src/types/internal/material.ts
+++ b/packages/sdk/src/types/internal/material.ts
@@ -1,0 +1,26 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { AssetLike, Material, MaterialLike } from '../..';
+import { InternalPatchable } from '../patchable';
+
+/**
+ * @hidden
+ */
+export class InternalMaterial implements InternalPatchable<AssetLike> {
+    public observing = true;
+    public patch: AssetLike;
+
+    public constructor(public material: Material) { }
+
+    public getPatchAndReset(): AssetLike {
+        const patch = this.patch;
+        if (patch) {
+            patch.id = this.material.id;
+            delete this.patch;
+        }
+        return patch;
+    }
+}

--- a/packages/sdk/src/types/network/payloads/assets.ts
+++ b/packages/sdk/src/types/network/payloads/assets.ts
@@ -26,6 +26,12 @@ export type AssetsLoaded = Payload & {
     failureMessage: string;
 };
 
+/** @hidden */
+export type AssetUpdate = Payload & {
+    type: 'asset-update';
+    asset: Partial<AssetLike>;
+};
+
 /**
  * @hidden
  */

--- a/packages/sdk/src/types/network/payloads/payloads.ts
+++ b/packages/sdk/src/types/network/payloads/payloads.ts
@@ -65,6 +65,7 @@ export type PayloadType
     | 'update-background-behaviors'
     | 'load-assets'
     | 'assets-loaded'
+    | 'asset-update'
     | 'look-at'
     ;
 

--- a/packages/sdk/src/types/patchable.ts
+++ b/packages/sdk/src/types/patchable.ts
@@ -1,0 +1,22 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * @hidden
+ */
+export interface InternalPatchable<T> {
+    observing: boolean;
+    patch: T;
+    getPatchAndReset(): T;
+}
+
+/**
+ * @hidden
+ */
+export interface Patchable<T> {
+    internal: InternalPatchable<T>;
+    toJSON(): T;
+    copy(from: Partial<T>): this;
+}

--- a/packages/sdk/src/types/runtime/actor.ts
+++ b/packages/sdk/src/types/runtime/actor.ts
@@ -32,6 +32,7 @@ import { createForwardPromise, ForwardPromise } from '../forwardPromise';
 import { InternalActor } from '../internal/actor';
 import { CollisionEventType, CreateColliderType } from '../network/payloads';
 import { SubscriptionType } from '../network/subscriptionType';
+import { Patchable } from '../patchable';
 import { Behavior } from './behaviors';
 
 /**
@@ -61,7 +62,7 @@ export interface ActorSet {
 /**
  * An actor represents an object instantiated on the host.
  */
-export class Actor implements ActorLike {
+export class Actor implements ActorLike, Patchable<ActorLike> {
     // tslint:disable:variable-name
     private _internal: InternalActor;
     /** @hidden */
@@ -111,7 +112,7 @@ export class Actor implements ActorLike {
         this._parentId = value;
         this.actorChanged('parentId');
     }
-    public get material() { return this._context.assets.byId(this._materialId) as Material; }
+    public get material() { return this._context.assetManager.assets[this._materialId] as Material; }
     public set material(value) {
         this.materialId = value && value.id || null;
     }
@@ -120,7 +121,7 @@ export class Actor implements ActorLike {
         if (value && value.startsWith('0000')) {
             value = null;
         }
-        if (!this.context.assets.byId(value)) {
+        if (!this.context.assetManager.assets[value]) {
             value = null; // throw?
         }
         this._materialId = value;

--- a/packages/sdk/src/types/runtime/assets/asset.ts
+++ b/packages/sdk/src/types/runtime/assets/asset.ts
@@ -54,9 +54,9 @@ export interface AssetLike {
 /** The base class for all asset types. */
 export class Asset implements AssetLike {
     // tslint:disable:variable-name
-    private _id: string;
-    private _name: string;
-    private _source: AssetSource;
+    protected _id: string;
+    protected _name: string;
+    protected _source: AssetSource;
     // tslint:enable:variable-name
 
     /** @inheritdoc */
@@ -68,7 +68,7 @@ export class Asset implements AssetLike {
     /** @inheritdoc */
     public get source() { return this._source; }
 
-    protected constructor(private manager: AssetManager, def: AssetLike) {
+    protected constructor(public manager: AssetManager, def: AssetLike) {
         this._id = def.id;
         this._name = def.name;
         this._source = def.source;
@@ -81,6 +81,15 @@ export class Asset implements AssetLike {
             name: this._name,
             source: this._source
         };
+    }
+
+    /** @hidden */
+    protected copy(from: Partial<AssetLike>): void {
+        // tslint:disable:curly
+        if (from.id) this._id = from.id;
+        if (from.name) this._name = from.name;
+        if (from.source) this._source = from.source;
+        // tslint:enable:curly
     }
 
     /** @hidden */

--- a/packages/sdk/src/types/runtime/assets/asset.ts
+++ b/packages/sdk/src/types/runtime/assets/asset.ts
@@ -54,9 +54,9 @@ export interface AssetLike {
 /** The base class for all asset types. */
 export class Asset implements AssetLike {
     // tslint:disable:variable-name
-    protected _id: string;
-    protected _name: string;
-    protected _source: AssetSource;
+    private _id: string;
+    private _name: string;
+    private _source: AssetSource;
     // tslint:enable:variable-name
 
     /** @inheritdoc */

--- a/packages/sdk/src/types/runtime/assets/assetManager.ts
+++ b/packages/sdk/src/types/runtime/assets/assetManager.ts
@@ -13,18 +13,20 @@ import { AssetsLoaded, LoadAssets } from '../../network/payloads';
  * and use the assets by ID on actors (e.g. [[Actor.CreateFromPrefab]]).
  */
 export class AssetManager {
-    private assets: { [id: string]: Asset } = {};
-    private groups: { [k: string]: AssetGroup } = {};
+    // tslint:disable:variable-name
+    private _assets: { [id: string]: Asset } = {};
+    private _groups: { [k: string]: AssetGroup } = {};
+    // tslint:enable:variable-name
     private inFlightLoads: { [k: string]: Promise<AssetGroup> } = {};
 
     /** @hidden */
-    public constructor(private context: Context) { }
+    public constructor(public context: Context) { }
 
     /** Fetch a group by name. */
-    public group(name: string) { return this.groups[name]; }
+    public get groups() { return Object.freeze({ ...this._groups }); }
 
     /** Fetch an asset by id. */
-    public byId(id: string) { return this.assets[id]; }
+    public get assets() { return Object.freeze({ ...this._assets }); }
 
     /**
      * @returns A promise that resolves when all pending asset load requests have been
@@ -86,10 +88,10 @@ export class AssetManager {
             def.source = group.source;
             const asset = Asset.Parse(this, def);
             group.add(asset);
-            this.assets[def.id] = asset;
+            this._assets[def.id] = asset;
         }
 
-        this.groups[groupName] = group;
+        this._groups[groupName] = group;
         return group;
     }
 

--- a/packages/sdk/src/types/runtime/assets/material.ts
+++ b/packages/sdk/src/types/runtime/assets/material.ts
@@ -61,6 +61,7 @@ export class Material extends Asset implements MaterialLike, Patchable<AssetLike
         }
 
         this._color.copy(def.material.color);
+        // material patching: observe the color for changed values, and write them to a patch
         observe(this._color, 'color', (...path: string[]) => this.materialChanged(path));
     }
 

--- a/packages/sdk/src/types/runtime/assets/material.ts
+++ b/packages/sdk/src/types/runtime/assets/material.ts
@@ -5,6 +5,10 @@
 
 import { Asset, AssetLike, AssetManager } from '.';
 import { Color3, Color4 } from '../../../math';
+import observe from '../../../utils/observe';
+import readPath from '../../../utils/readPath';
+import { InternalMaterial } from '../../internal/material';
+import { Patchable } from '../../patchable';
 
 /**
  * Describes the properties of a Material.
@@ -34,10 +38,14 @@ export enum AlphaMode {
 /**
  * Represents a material on a mesh.
  */
-export class Material extends Asset implements MaterialLike {
+export class Material extends Asset implements MaterialLike, Patchable<AssetLike> {
     // tslint:disable:variable-name
     private _color = Color4.FromColor3(Color3.White(), 1.0);
+    private _internal = new InternalMaterial(this);
     // tslint:enable:variable-name
+
+    /** @hidden */
+    public get internal() { return this._internal; }
 
     /** @inheritdoc */
     public get color() { return this._color; }
@@ -53,10 +61,26 @@ export class Material extends Asset implements MaterialLike {
         }
 
         this._color.copy(def.material.color);
+        observe(this._color, 'color', (...path: string[]) => this.materialChanged(path));
+    }
 
-        // materials are immutable for now, so don't let people change
-        // the color, for fear of desync
-        Object.freeze(this._color);
+    public copy(from: Partial<AssetLike>): this {
+        if (!from) {
+            return this;
+        }
+
+        // Pause change detection while we copy the values into the actor.
+        const wasObserving = this.internal.observing;
+        this.internal.observing = false;
+
+        // tslint:disable:curly
+        super.copy(from);
+        if (from.material && from.material.color)
+            this._color.copy(from.material.color);
+        // tslint:enable:curly
+
+        this.internal.observing = wasObserving;
+        return this;
     }
 
     /** @hidden */
@@ -67,5 +91,13 @@ export class Material extends Asset implements MaterialLike {
                 color: this._color.toJSON()
             }
         };
+    }
+
+    private materialChanged(path: string[]): void {
+        if (this.internal.observing) {
+            this.manager.context.internal.incrementGeneration();
+            this.internal.patch = this.internal.patch || {} as AssetLike;
+            readPath(this, this.internal.patch, ...path);
+        }
     }
 }

--- a/packages/sdk/src/types/runtime/assets/material.ts
+++ b/packages/sdk/src/types/runtime/assets/material.ts
@@ -7,7 +7,7 @@ import { Asset, AssetLike, AssetManager } from '.';
 import { Color3, Color4 } from '../../../math';
 import observe from '../../../utils/observe';
 import readPath from '../../../utils/readPath';
-import { InternalMaterial } from '../../internal/material';
+import { InternalAsset } from '../../internal/asset';
 import { Patchable } from '../../patchable';
 
 /**
@@ -41,7 +41,7 @@ export enum AlphaMode {
 export class Material extends Asset implements MaterialLike, Patchable<AssetLike> {
     // tslint:disable:variable-name
     private _color = Color4.FromColor3(Color3.White(), 1.0);
-    private _internal = new InternalMaterial(this);
+    private _internal = new InternalAsset(this);
     // tslint:enable:variable-name
 
     /** @hidden */

--- a/packages/sdk/src/types/runtime/assets/material.ts
+++ b/packages/sdk/src/types/runtime/assets/material.ts
@@ -96,8 +96,8 @@ export class Material extends Asset implements MaterialLike, Patchable<AssetLike
     private materialChanged(path: string[]): void {
         if (this.internal.observing) {
             this.manager.context.internal.incrementGeneration();
-            this.internal.patch = this.internal.patch || {} as AssetLike;
-            readPath(this, this.internal.patch, ...path);
+            this.internal.patch = this.internal.patch || { material: {} } as AssetLike;
+            readPath(this, this.internal.patch.material, ...path);
         }
     }
 }

--- a/packages/sdk/src/types/runtime/assets/prefab.ts
+++ b/packages/sdk/src/types/runtime/assets/prefab.ts
@@ -4,16 +4,22 @@
  */
 
 import { Asset, AssetLike, AssetManager } from '.';
+import { InternalAsset } from '../../internal/asset';
+import { Patchable } from '../../patchable';
 
 export interface PrefabLike {
     /** The number of actors this prefab contains. */
     actorCount: number;
 }
 
-export class Prefab extends Asset implements PrefabLike {
+export class Prefab extends Asset implements PrefabLike, Patchable<AssetLike> {
     // tslint:disable:variable-name
     private _actorCount: number;
+    private _internal = new InternalAsset(this);
     // tslint:enable:variable-name
+
+    /** @hidden */
+    public get internal() { return this._internal; }
 
     /** @inheritdoc */
     public get actorCount() { return this._actorCount; }
@@ -29,6 +35,25 @@ export class Prefab extends Asset implements PrefabLike {
         }
 
         this._actorCount = def.prefab.actorCount;
+    }
+
+    public copy(from: Partial<AssetLike>): this {
+        if (!from) {
+            return this;
+        }
+
+        // Pause change detection while we copy the values into the actor.
+        const wasObserving = this.internal.observing;
+        this.internal.observing = false;
+
+        // tslint:disable:curly
+        super.copy(from);
+        if (from.prefab)
+            this._actorCount = from.prefab.actorCount;
+        // tslint:enable:curly
+
+        this.internal.observing = wasObserving;
+        return this;
     }
 
     /** @hidden */

--- a/packages/sdk/src/types/runtime/context.ts
+++ b/packages/sdk/src/types/runtime/context.ts
@@ -36,12 +36,12 @@ export class Context {
     /** @hidden */
     public get emitter() { return this._emitter; }
 
-    private _assets: AssetManager;
+    private _assetManager: AssetManager;
     private _sessionId: string;
     private _conn: Connection;
     // tslint:enable:variable-name
 
-    public get assets() { return this._assets; }
+    public get assetManager() { return this._assetManager; }
     public get sessionId() { return this._sessionId; }
     public get conn() { return this._conn; }
     public get actors() { return Object.keys(this.internal.actorSet).map(actorId => this.internal.actorSet[actorId]); }
@@ -62,7 +62,7 @@ export class Context {
         this._conn = settings.connection || new NullConnection();
         this._sessionId = settings.sessionId || UUID();
         this._internal = new InternalContext(this);
-        this._assets = new AssetManager(this);
+        this._assetManager = new AssetManager(this);
     }
 
     /**


### PR DESCRIPTION
* Updated `Material` to generate patches.
* Implemented interfaces `Patchable<T>` and `InternalPatchable<T>`, which the context uses to check for updates.
* `StateUpdate` messages can now contain both `ActorUpdate`s and `AssetUpdate`s.
* Added a new functional test that demonstrates shared mutable materials.
* Renamed the context asset manager to `assetManager` from `assets`. Also rearranged some APIs in the manager for better usability.
