### PR TITLE
Fix serialization failure when nulling synced actor property

### DIFF
--- a/packages/sdk/src/utils/filterEmpty.ts
+++ b/packages/sdk/src/utils/filterEmpty.ts
@@ -8,7 +8,9 @@
  * If `obj` is an empty object, return undefined.
  */
 export default function filterEmpty(obj: any) {
-    if (typeof obj !== 'object' || Object.keys(obj).length) {
+    if (typeof obj === 'object' && obj !== null && !Object.keys(obj).length) {
+        return undefined;
+    } else {
         return obj;
     }
 }


### PR DESCRIPTION
This function threw an exception if `null` were passed in, as its type is `'object'`, but doesn't support Object.keys.