### PR TITLE
Add missing catch statement

### DIFF
--- a/packages/functional-tests/tsconfig.json
+++ b/packages/functional-tests/tsconfig.json
@@ -16,6 +16,9 @@
   "references": [
     {
       "path": "../sdk"
+    },
+    {
+      "path": "../gltf-gen"
     }
   ]
 }

--- a/packages/sdk/src/types/runtime/actor.ts
+++ b/packages/sdk/src/types/runtime/actor.ts
@@ -26,6 +26,7 @@ import {
     LookAtMode,
     PrimitiveDefinition
 } from '../..';
+import { log } from '../../log';
 import BufferedEventEmitter from '../../utils/bufferedEventEmitter';
 import observe from '../../utils/observe';
 import readPath from '../../utils/readPath';
@@ -569,7 +570,9 @@ export class Actor implements ActorLike {
             this.internal.patch = this.internal.patch || {} as ActorLike;
             readPath(this, this.internal.patch, ...path);
             // Wait until the actor has been created before triggering a state update.
-            this.created().then(() => this.context.internal.incrementGeneration());
+            this.created()
+                .then(() => this.context.internal.incrementGeneration())
+                .catch(reason => log.error('app', reason));
         }
     }
 }


### PR DESCRIPTION
tslint doesn't report this when I build from vscode, but does when building from command line. Thanks goes to @renebohne for the heads up.

Also: Fixed up a missing project dependency.