### PR TITLE
Big cleanup of message handling in the multi-peer adapter

### DIFF
--- a/packages/sdk/src/adapters/multipeer/index.ts
+++ b/packages/sdk/src/adapters/multipeer/index.ts
@@ -8,3 +8,4 @@ export * from './session';
 export * from './client';
 export * from './syncActor';
 export * from './protocols';
+export * from './rules';

--- a/packages/sdk/src/adapters/multipeer/protocols/clientExecution.ts
+++ b/packages/sdk/src/adapters/multipeer/protocols/clientExecution.ts
@@ -4,7 +4,7 @@
  */
 
 import { Client } from '..';
-import * as MRESDK from '../../..';
+import { Message } from '../../..';
 import * as Protocols from '../../../protocols';
 
 /**
@@ -52,7 +52,7 @@ export class ClientExecution extends Protocols.Protocol implements Protocols.Mid
         }, 1000 * (4 + 2 * Math.random()));
     }
 
-    public beforeRecv = (message: MRESDK.Message): MRESDK.Message => {
+    public beforeRecv = (message: Message): Message => {
         if (this.promises[message.replyToId]) {
             // If we have a queued promise for this message, let it through
             return message;

--- a/packages/sdk/src/adapters/multipeer/protocols/clientSync.ts
+++ b/packages/sdk/src/adapters/multipeer/protocols/clientSync.ts
@@ -3,20 +3,43 @@
  * Licensed under the MIT License.
  */
 
-import { Client, SyncActor } from '..';
-import * as MRESDK from '../../..';
+import { Client, MissingRule, Rules, SyncActor } from '..';
+import { Message } from '../../..';
+import { log } from '../../../log';
 import * as Protocols from '../../../protocols';
 import * as Payloads from '../../../types/network/payloads';
 import { ExportedPromise } from '../../../utils/exportedPromise';
 
+// tslint:disable:object-literal-key-quotes no-console
+
 /**
  * @hidden
- * Synchronizes application state with a client
+ */
+export type SynchronizationStage =
+    'always' |
+    'load-assets' |
+    'create-actors' |
+    'create-animations' |
+    'sync-animations' |
+    'set-behaviors' |
+    'never';
+
+/**
+ * @hidden
+ * Synchronizes application state with a client.
  */
 export class ClientSync extends Protocols.Protocol {
+    private inProgressStages: SynchronizationStage[] = [];
+    private completedStages: SynchronizationStage[] = [];
 
-    private createActorsInvoked = false;
-    private syncAssetsInvoked = false;
+    // The order of synchronization stages.
+    private sequence: SynchronizationStage[] = [
+        'load-assets',
+        'create-actors',
+        'set-behaviors',
+        'create-animations',
+        'sync-animations',
+    ];
 
     /** @override */
     public get name(): string { return `${this.constructor.name} client ${this.client.id}`; }
@@ -25,109 +48,168 @@ export class ClientSync extends Protocols.Protocol {
         super(client.conn);
         // Behave like a server-side endpoint (send heartbeats, measure connection quality)
         this.use(new Protocols.ServerPreprocessing());
+        // Immediagely mark the 'always' stage as in progress.
+        this.beginStage('always');
     }
 
-    /** @override */
-    public sendMessage(message: MRESDK.Message, promise?: ExportedPromise) {
-        if (message.payload.type === 'heartbeat' ||
-            message.payload.type === 'sync-animations' ||
-            message.payload.type === 'interpolate-actor') {
-            // These messages are part of the synchronization process and so we always let them through.
-            super.sendMessage(message, promise);
-        } else if (this.syncAssetsInvoked && message.payload.type === 'load-assets') {
-            // These messages are load-asset messages. We want to queue these up because we've already
-            // passed the `syncAssets` phase of the synchronization process, so we'll need to send these
-            // later in the `syncQueuedMessages` phase.
-            this.client.queueMessage(message, promise);
-        } else if (this.createActorsInvoked && message.payload.type.startsWith('create-')) {
-            // These messages are actor creation messages. We want to queue these up because we've already
-            // passed the `createActors` phase of the synchronization process, so we'll need to send these
-            // later in the `syncQueuedMessages` phase.
-            this.client.queueMessage(message, promise);
-        } else if (!Client.ShouldIgnorePayloadWhileJoining(message.payload.type)) {
-            // A message we should queue for delivery in the `syncQueuedMessages` phase of synchronization.
-            this.client.queueMessage(message, promise);
+    /**
+     * @override
+     * Handle the outgoing message according to the synchronization rules specified for this payload.
+     */
+    public sendMessage(message: Message, promise?: ExportedPromise) {
+        const handling = this.handlingForMessage(message);
+        // tslint:disable-next-line:switch-default
+        switch (handling) {
+            case 'allow': {
+                super.sendMessage(message, promise);
+                break;
+            }
+            case 'queue': {
+                this.client.queueMessage(message, promise);
+                break;
+            }
+            case 'ignore': {
+                break;
+            }
+            case 'error': {
+                // tslint:disable-next-line: max-line-length
+                console.error(`[ERROR] ${this.name}: Invalid message for send during synchronization stage: ${message.payload.type}. In progress: ${this.inProgressStages.join(',')}. Complete: ${this.completedStages.join(',')}.`);
+            }
         }
     }
 
-    /** @private */
+    private handlingForMessage(message: Message) {
+        const rule = Rules[message.payload.type] || MissingRule;
+        let handling = rule.synchronization.before;
+        if (this.isStageComplete(rule.synchronization.stage)) {
+            handling = rule.synchronization.after;
+        } else if (this.isStageInProgress(rule.synchronization.stage)) {
+            handling = rule.synchronization.during;
+        }
+        return handling;
+    }
+
+    private isStageComplete(stage: SynchronizationStage) {
+        return this.completedStages.includes(stage);
+    }
+
+    private isStageInProgress(stage: SynchronizationStage) {
+        return this.inProgressStages.includes(stage);
+    }
+
+    private beginStage(stage: SynchronizationStage) {
+        log.debug('network', `${this.name} - begin stage '${stage}'`);
+        this.inProgressStages = [...this.inProgressStages, stage];
+    }
+
+    private completeStage(stage: SynchronizationStage) {
+        log.debug('network', `${this.name} - complete stage '${stage}'`);
+        this.inProgressStages = this.inProgressStages.filter(item => item !== stage);
+        this.completedStages = [...this.completedStages, stage];
+    }
+
+    private async executeStage(stage: SynchronizationStage) {
+        const handler = (this as any)[`stage:${stage}`];
+        if (handler) {
+            await handler();
+        } else {
+            console.error(`[ERROR] ${this.name}: No handler for stage ${stage}!`);
+        }
+    }
+
+    /**
+     * @hidden
+     * Start synchronizing once we receive the `sync-request` message from the client.
+     */
     public 'recv-sync-request' = async (payload: Payloads.SyncRequest) => {
         if (this.client.session.peerAuthoritative) {
             // Do a quick measurement of connection latency
             const heartbeat = new Protocols.Heartbeat(this);
             await heartbeat.runIterations(10);
-            // Sync all the assets
-            await this.syncAssets();
-            // Sync all the actors
-            await this.syncActors();
+            // Run all the synchronization stages.
+            for (const stage of this.sequence) {
+                this.beginStage(stage);
+                await this.executeStage(stage);
+                this.completeStage(stage);
+                await this.sendQueuedMessages();
+            }
         }
-        // Stop queuing messages
-        this.sendMessage = super.sendMessage;
-        // Send queued messages
-        await this.client.syncQueuedMessages();
-        // Notify sync complete
-        this.sendPayload({
-            type: 'sync-complete',
-        } as Payloads.SyncComplete);
+        this.completeStage('always');
+        // Notify the client we're done synchronizing.
+        this.sendPayload({ type: 'sync-complete' } as Payloads.SyncComplete);
+        // Send all remaining queued messages.
+        await this.sendQueuedMessages();
+        // Detach from the connection.
         this.stopListening();
+        // Let the next protocol know we're complete.
         this.emit('protocol.sync-complete');
     }
 
-    private async syncAssets(): Promise<void> {
-        this.syncAssetsInvoked = true;
+    /**
+     * @hidden
+     * Driver for the `load-assets` synchronization stage.
+     */
+    public 'stage:load-assets' = async () => {
+        // Send all cached load-assets messages.
         await Promise.all(
-            this.client.session.assetSet.map(
-                msg => this.sendAndExpectResponse(msg)));
+            this.client.session.assets.map(
+                message => this.sendAndExpectResponse(message)));
+        // Send all cached asset-update messages.
+        this.client.session.assetUpdates.map(
+            payload => this.sendMessage({ payload }));
     }
 
-    private async syncActors() {
-        await this.createActors();
-        await this.createAnimations();
-        this.createBehaviors();
-        await this.syncAnimations();
+    /**
+     * @hidden
+     * Driver for the `create-actors` synchronization stage.
+     */
+    public 'stage:create-actors' = async () => {
+        // Sync cached create-actor hierarchies, starting at roots.
+        await Promise.all(
+            this.client.session.rootActors.map(
+                syncActor => this.createActorRecursive(syncActor)));
     }
 
-    private createActors(): Promise<any> {
-        // Sync actor hierarchies, starting at roots
-        const promises = [];
-        for (const actor of this.client.session.rootActors) {
-            promises.push(this.createActorRecursive(actor));
-        }
-        // After sending the create* messages we must let future messages through when they're sent, even while this
-        // client is still in the process of joining.
-        this.createActorsInvoked = true;
-        // Wait for all actors to be created
-        return Promise.all(promises.filter(promise => !!promise));
+    /**
+     * @hidden
+     * Driver for the `set-behaviors` synchronization stage.
+     */
+    public 'stage:set-behaviors' = async () => {
+        // Send all cached set-behavior messages.
+        this.client.session.actors.map(syncActor => this.createActorBehavior(syncActor));
+        return Promise.resolve();
     }
 
-    private createAnimations(): Promise<any> {
-        const promises = [];
-        for (const actor of this.client.session.actors) {
-            this.createActorInterpolations(actor);
-            promises.push(this.createActorAnimations(actor));
-        }
-        return Promise.all(promises);
+    /**
+     * @hidden
+     * Driver for the `create-animations` synchronization stage.
+     */
+    public 'stage:create-animations' = async () => {
+        // Send all cached interpolate-actor and creaet-animation messages.
+        this.client.session.actors.map(syncActor => this.createActorInterpolations(syncActor));
+        await Promise.all([
+            this.client.session.actors.map(syncActor => this.createActorAnimations(syncActor))]);
     }
 
-    private createBehaviors(): void {
-        for (const actor of this.client.session.actors) {
-            this.createActorBehavior(actor);
-        }
-    }
-
-    private syncAnimations(): Promise<any> {
-        // Don't send the sync-animations message to ourselves
+    /**
+     * @hidden
+     * Driver for the `sync-animations` synchronization stage.
+     */
+    public 'stage:sync-animations' = async () => {
+        // Don't send the sync-animations message to ourselves.
         if (this.client.session.authoritativeClient.order === this.client.order) {
             return Promise.resolve();
         }
         return new Promise<void>((resolve, reject) => {
+            // Request the current state of all animations from the authoritative client.
+            // TODO: Improve this (don't rely on a peer).
             const authoritativeClient = this.client.session.authoritativeClient;
             authoritativeClient.sendPayload({
                 type: 'sync-animations',
             } as Payloads.SyncAnimations, {
                     resolve: (payload: Payloads.SyncAnimations) => {
                         // We've received the sync-animations payload from the authoritative
-                        // client, now pass it to the joining client
+                        // client, now pass it to the joining client.
                         for (const animationState of payload.animationStates) {
                             // Account for latency on the authoritative peer's connection.
                             animationState.animationTime += authoritativeClient.conn.quality.latencyMs.value / 2000;
@@ -174,11 +256,10 @@ export class ClientSync extends Protocols.Protocol {
     }
 
     private createActorAnimations(actor: Partial<SyncActor>): Promise<any> {
-        const promises = [];
-        for (const createAnimation of actor.createdAnimations || []) {
-            promises.push(this.sendAndExpectResponse(createAnimation.message));
-        }
-        return Promise.all(promises);
+        return Promise.all([
+            (actor.createdAnimations || [])
+                .map(createdAnimation => this.sendAndExpectResponse(createdAnimation.message))
+        ]);
     }
 
     private createActorInterpolations(actor: Partial<SyncActor>) {
@@ -192,10 +273,10 @@ export class ClientSync extends Protocols.Protocol {
         }
     }
 
-    private sendAndExpectResponse(message: MRESDK.Message) {
+    private sendAndExpectResponse(message: Message) {
         return new Promise<void>((resolve, reject) => {
             super.sendMessage(message, {
-                resolve: (replyPayload: any, replyMessage: MRESDK.Message) => {
+                resolve: (replyPayload: any, replyMessage: Message) => {
                     if (this.client.authoritative) {
                         // If this client is authoritative while synchonizing, then it is the only client joined.
                         // In this case we want to send the reply message back to the app since it is expecting it.
@@ -205,5 +286,25 @@ export class ClientSync extends Protocols.Protocol {
                 }, reject
             });
         });
+    }
+
+    public async sendQueuedMessages() {
+        // 1. Get the subset of queued messages that can be sent now.
+        // 2. Send the messages and wait for expected replies.
+        // 3. Repeat until no more messages to send.
+        do {
+            const queuedMessages = this.client.filterQueuedMessages((queuedMessage) => {
+                const message = queuedMessage.message;
+                const handling = this.handlingForMessage(message);
+                return handling === 'allow';
+            });
+            if (!queuedMessages.length) {
+                break;
+            }
+            for (const queuedMessage of queuedMessages) {
+                this.sendMessage(queuedMessage.message, queuedMessage.promise);
+            }
+            await this.drainPromises();
+        } while (true);
     }
 }

--- a/packages/sdk/src/adapters/multipeer/protocols/clientSync.ts
+++ b/packages/sdk/src/adapters/multipeer/protocols/clientSync.ts
@@ -185,7 +185,7 @@ export class ClientSync extends Protocols.Protocol {
      * Driver for the `create-animations` synchronization stage.
      */
     public 'stage:create-animations' = async () => {
-        // Send all cached interpolate-actor and creaet-animation messages.
+        // Send all cached interpolate-actor and create-animation messages.
         this.client.session.actors.map(syncActor => this.createActorInterpolations(syncActor));
         await Promise.all([
             this.client.session.actors.map(syncActor => this.createActorAnimations(syncActor))]);

--- a/packages/sdk/src/adapters/multipeer/protocols/sessionExecution.ts
+++ b/packages/sdk/src/adapters/multipeer/protocols/sessionExecution.ts
@@ -4,7 +4,7 @@
  */
 
 import { Session } from '..';
-import * as MRESDK from '../../../';
+import { Message } from '../../..';
 import * as Protocols from '../../../protocols';
 
 /**
@@ -22,7 +22,7 @@ export class SessionExecution extends Protocols.Protocol implements Protocols.Mi
     }
 
     /** @private */
-    public beforeRecv = (message: MRESDK.Message): MRESDK.Message => {
+    public beforeRecv = (message: Message): Message => {
         // Notify listeners we received a message from the application
         this.emit('recv', message);
         // Cancel the message

--- a/packages/sdk/src/adapters/multipeer/rules.ts
+++ b/packages/sdk/src/adapters/multipeer/rules.ts
@@ -1,0 +1,1181 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import deepmerge from 'deepmerge';
+import { Client, Session, SynchronizationStage } from '.';
+import { Message, WebSocket } from '../..';
+import * as Payloads from '../../types/network/payloads';
+import { ExportedPromise } from '../../utils/exportedPromise';
+
+// tslint:disable:variable-name new-parens no-console
+
+/**
+ * @hidden
+ * Indicates how to handle live message traffic during the client join process.
+ */
+export type MessageHandling =
+    /**
+     * Ignore the message.
+     */
+    'ignore' |
+    /**
+     * Queue message for later delivery.
+     */
+    'queue' |
+    /**
+     * Allow the message to be sent.
+     */
+    'allow' |
+    /**
+     * Trying to send this message indicates an operational error.
+     */
+    'error';
+
+/**
+ * @hidden
+ * Defines how specific messages are processed by different parts of the multipeer adapter.
+ */
+export type Rule = {
+    /**
+     * During handshake, apply this kind of handling to outgoing messages.
+     */
+    handshake: {
+        /**
+         * `during` - How to handle outgoing messages of this type while the handshake protocol is active.
+         */
+        during: MessageHandling;
+    },
+
+    /**
+     * During synchronization, apply these rules to outgoing messages.
+     */
+    synchronization: {
+        /**
+         * `stage` - The synchronization stage that serves as the inflection point for this message.
+         */
+        stage: SynchronizationStage;
+        /**
+         * `before` - How to handle outgoing messages of this type before `stage` has begun.
+         */
+        before: MessageHandling;
+        /**
+         * `during` - How to handle outgoing messages of this type while `stage` is active.
+         */
+        during: MessageHandling;
+        /**
+         * `after` - How to handle outgoing messages of this type after `stage` is complete.
+         */
+        after: MessageHandling;
+    },
+
+    /**
+     * Message preprocessing applied by the Client class.
+     */
+    client: {
+        /**
+         * Called before a message is queued for later delivery to a client.
+         * @param session The current session.
+         * @param client The client to receive the message.
+         * @param message The message to queue.
+         * @param promise Optional promise to complete once the reply message is received.
+         * @returns Return the message if you want it to continue to be processed. Return null/undefined
+         * to stop processing of the message.
+         */
+        beforeQueueMessageForClient: (
+            session: Session, client: Client, message: any, promise: ExportedPromise) => Message;
+    },
+
+    /**
+     * Message preprocessing applied by the Session class.
+     */
+    session: {
+        /**
+         * Called after a message is received from the app, before propagating the message.
+         * @param session The current session.
+         * @param message The message.
+         * @returns Return the message if you want it to continue to be processed. Return a falsy value
+         * to stop processing of the message.
+         */
+        beforeReceiveFromApp: (
+            session: Session, message: any) => Message;
+        /**
+         * Called after a message is received from a client, before propagating the message.
+         * @param session The current session.
+         * @param client The client who sent the message.
+         * @param message The message itself (also contains the payload).
+         * @returns Return the message if you want it to continue to be processed. Return a falsy value
+         * to stop processing of the message.
+         */
+        beforeReceiveFromClient: (
+            session: Session, client: Client, message: any) => Message;
+    }
+};
+
+/**
+ * @hidden
+ * The DefaultRule provides reasonable default rule settings, ensuring all fields are assigned.
+ */
+export const DefaultRule: Rule = {
+    handshake: {
+        during: 'queue'
+    },
+    synchronization: {
+        stage: 'always',
+        before: 'allow',
+        during: 'allow',
+        after: 'allow'
+    },
+    client: {
+        beforeQueueMessageForClient: (
+            session: Session, client: Client, message: any, promise: ExportedPromise) => {
+            return message;
+        }
+    },
+    session: {
+        beforeReceiveFromApp: (
+            session: Session, message: Message) => {
+            return message;
+        },
+        beforeReceiveFromClient: (
+            session: Session, client: Client, message: Message) => {
+            return message;
+        },
+    }
+};
+
+/**
+ * @hidden
+ * MissingRule alerts the SDK developer that they need to define a Rule for the payload.
+ */
+export const MissingRule: Rule = {
+    ...DefaultRule,
+    client: {
+        beforeQueueMessageForClient: (
+            session: Session, client: Client, message: any, promise: ExportedPromise) => {
+            console.error(`[ERROR] No rule defined for payload ${message.payload.type}! Add an entry in rules.ts.`);
+            return message;
+        }
+    },
+    session: {
+        beforeReceiveFromApp: (
+            session: Session, message: Message) => {
+            console.error(`[ERROR] No rule defined for payload ${message.payload.type}! Add an entry in rules.ts.`);
+            return message;
+        },
+        beforeReceiveFromClient: (
+            session: Session, client: Client, message: Message) => {
+            console.error(`[ERROR] No rule defined for payload ${message.payload.type}! Add an entry in rules.ts.`);
+            return message;
+        },
+    }
+};
+
+/**
+ * @hidden
+ * Handling for client-only messages.
+ */
+const ClientOnlyRule: Rule = {
+    ...DefaultRule,
+    handshake: {
+        during: 'error'
+    },
+    synchronization: {
+        stage: 'always',
+        before: 'error',
+        during: 'error',
+        after: 'error'
+    },
+    client: {
+        beforeQueueMessageForClient: (
+            session: Session, client: Client, message: any, promise: ExportedPromise) => {
+            console.error(`[ERROR] session tried to queue a client-only message: ${message.payload.type}!`);
+            return message;
+        }
+    },
+    session: {
+        ...DefaultRule.session,
+        beforeReceiveFromApp: (session: Session, message: Message) => {
+            console.error(`[ERROR] app tried to send a client-only message: ${message.payload.type}!`);
+            return undefined;
+        }
+    }
+};
+
+/**
+ * @hidden
+ * A global collection of message rules used by different parts of the multipeer adapter.
+ * Getting a compiler error here? It is likely that `Rules` is missing a rule for the new payload type you added.
+ * *** KEEP ENTRIES SORTED ***
+ */
+export const Rules: { [id in Payloads.PayloadType]: Rule } = {
+    // ========================================================================
+    'actor-correction': {
+        ...DefaultRule,
+        handshake: {
+            during: 'ignore'
+        },
+        synchronization: {
+            stage: 'create-actors',
+            before: 'ignore',
+            during: 'queue',
+            after: 'allow'
+        },
+        client: {
+            beforeQueueMessageForClient: (
+                session: Session,
+                client: Client,
+                message: Message,
+                promise: ExportedPromise
+            ) => {
+                message.payload.type = 'actor-update';
+                client.queueMessage(message, promise);
+                return undefined;
+            }
+        },
+        session: {
+            // Whenever we encounter an actor-correction, convert it to an actor-update
+            // Eventually: Remove actor-correction payload type (requires DLL change).
+            beforeReceiveFromApp: (
+                session: Session,
+                message: Message<Payloads.ActorUpdate>
+            ) => {
+                message.payload.type = 'actor-update';
+                session.preprocessFromApp(message);
+                return undefined;
+            },
+            beforeReceiveFromClient: (
+                session: Session,
+                client: Client,
+                message: Message<Payloads.ActorUpdate>
+            ) => {
+                message.payload.type = 'actor-update';
+                session.preprocessFromClient(client, message);
+                return undefined;
+            }
+        }
+    },
+
+    // ========================================================================
+    'actor-update': {
+        ...DefaultRule,
+        handshake: {
+            during: 'ignore'
+        },
+        synchronization: {
+            stage: 'create-actors',
+            before: 'ignore',
+            during: 'queue',
+            after: 'allow'
+        },
+        client: {
+            beforeQueueMessageForClient: (
+                session: Session,
+                client: Client,
+                message: Message<Payloads.ActorUpdate>,
+                promise: ExportedPromise
+            ) => {
+                // Coalesce this update with the previously queued update if it exists, maintaining a single
+                // update for this actor rather than queuing a series of them.
+                const payload = message.payload;
+                const queuedMessage = client.queuedMessages
+                    .filter(value =>
+                        value.message.payload.type === 'actor-update' &&
+                        (value.message.payload as Payloads.ActorUpdate).actor.id === payload.actor.id).shift();
+                if (queuedMessage) {
+                    const existingPayload = queuedMessage.message.payload as Partial<Payloads.ActorUpdate>;
+                    existingPayload.actor = deepmerge(existingPayload.actor, payload.actor);
+                    return undefined;
+                }
+                return message;
+            }
+        },
+        session: {
+            ...DefaultRule.session,
+            beforeReceiveFromApp: (
+                session: Session,
+                message: Message<Payloads.ActorUpdate>
+            ) => {
+                session.cacheActorUpdateMessage(message);
+                return message;
+            },
+            beforeReceiveFromClient: (
+                session: Session,
+                client: Client,
+                message: Message<Payloads.ActorUpdate>
+            ) => {
+                // Check that this is the authoritative client.
+                if (client.authoritative) {
+                    // Check that the actor exists.
+                    const syncActor = session.actorSet[message.payload.actor.id];
+                    if (syncActor) {
+                        // Merge the update into the existing actor.
+                        session.cacheActorUpdateMessage(message);
+
+                        // Make a copy of the message so we can modify it.
+                        const payloadForClients = deepmerge(message.payload, {});
+
+                        // If animating, don't sync transform changes with other clients. Animations are desynchronized.
+                        if (session.isAnimating(syncActor)) {
+                            payloadForClients.actor.transform = undefined;
+                        }
+
+                        // Sync the change to the other clients.
+                        session.sendPayloadToClients(payloadForClients, client.id);
+
+                        // Determine whether to forward the message to the app based on subscriptions.
+                        let shouldSendToApp = false;
+                        const subscriptions = syncActor.created.message.payload.actor.subscriptions || [];
+                        if (message.payload.actor.transform &&
+                            Object.keys(message.payload.actor.transform) &&
+                            subscriptions.includes('transform')) {
+                            shouldSendToApp = true;
+                        } else if (message.payload.actor.rigidBody &&
+                            Object.keys(message.payload.actor.transform) &&
+                            subscriptions.includes('rigidbody')) {
+                            shouldSendToApp = true;
+                        }
+                        return shouldSendToApp ? message : undefined;
+                    }
+                }
+            }
+        }
+    },
+
+    // ========================================================================
+    'app2engine-rpc': {
+        ...DefaultRule,
+        handshake: {
+            during: 'queue'
+        },
+        synchronization: {
+            stage: 'always',
+            before: 'queue',
+            during: 'queue',
+            after: 'allow'
+        },
+        session: {
+            ...DefaultRule.session,
+            beforeReceiveFromApp: (
+                session: Session,
+                message: Message<Payloads.AppToEngineRPC>
+            ) => {
+                // Send the message only to the specified user.
+                if (message.payload.userId) {
+                    const client = session.clients.find(value => value.userId === message.payload.userId);
+                    if (client) {
+                        client.send(message);
+                    }
+                } else {
+                    // If no user specified then allow the message to be sent to all users.
+                    return message;
+                }
+            }
+        }
+    },
+
+    // ========================================================================
+    'asset-update': {
+        ...DefaultRule,
+        handshake: {
+            during: 'ignore'
+        },
+        synchronization: {
+            stage: 'load-assets',
+            before: 'ignore',
+            during: 'queue',
+            after: 'allow'
+        },
+        session: {
+            ...DefaultRule.session,
+            beforeReceiveFromApp: (
+                session: Session,
+                message: Message<Payloads.AssetUpdate>
+            ) => {
+                session.cacheAssetUpdateMessage(message);
+                return message;
+            }
+        }
+    },
+
+    // ========================================================================
+    'assets-loaded': {
+        ...ClientOnlyRule
+    },
+
+    // ========================================================================
+    'create-animation': {
+        ...DefaultRule,
+        handshake: {
+            during: 'ignore'
+        },
+        synchronization: {
+            stage: 'create-animations',
+            before: 'ignore',
+            during: 'allow',
+            after: 'allow'
+        },
+        session: {
+            ...DefaultRule.session,
+            beforeReceiveFromApp: (
+                session: Session,
+                message: Message<Payloads.CreateAnimation>
+            ) => {
+                const syncActor = session.actorSet[message.payload.actorId];
+                if (syncActor) {
+                    const enabled = message.payload.initialState && !!message.payload.initialState.enabled;
+                    syncActor.createdAnimations = syncActor.createdAnimations || [];
+                    syncActor.createdAnimations.push({ message, enabled });
+                }
+                return message;
+            }
+        }
+    },
+
+    // ========================================================================
+    'create-empty': {
+        ...DefaultRule,
+        handshake: {
+            during: 'ignore'
+        },
+        synchronization: {
+            stage: 'create-actors',
+            before: 'ignore',
+            during: 'queue',
+            after: 'allow'
+        },
+        session: {
+            ...DefaultRule.session,
+            beforeReceiveFromApp: (
+                session: Session,
+                message: Message<Payloads.CreateEmpty>
+            ) => {
+                session.cacheCreateActorMessage(message);
+                return message;
+            }
+        }
+    },
+
+    // ========================================================================
+    'create-from-gltf': {
+        ...DefaultRule,
+        handshake: {
+            during: 'ignore'
+        },
+        synchronization: {
+            stage: 'create-actors',
+            before: 'ignore',
+            during: 'queue',
+            after: 'allow'
+        },
+        session: {
+            ...DefaultRule.session,
+            beforeReceiveFromApp: (
+                session: Session,
+                message: Message<Payloads.CreateFromGltf>
+            ) => {
+                session.cacheCreateActorMessage(message);
+                return message;
+            }
+        }
+    },
+
+    // ========================================================================
+    'create-from-library': {
+        ...DefaultRule,
+        handshake: {
+            during: 'ignore'
+        },
+        synchronization: {
+            stage: 'create-actors',
+            before: 'ignore',
+            during: 'queue',
+            after: 'allow'
+        },
+        session: {
+            ...DefaultRule.session,
+            beforeReceiveFromApp: (
+                session: Session,
+                message: Message<Payloads.CreateFromLibrary>
+            ) => {
+                session.cacheCreateActorMessage(message);
+                return message;
+            }
+        }
+    },
+
+    // ========================================================================
+    'create-primitive': {
+        ...DefaultRule,
+        handshake: {
+            during: 'ignore'
+        },
+        synchronization: {
+            stage: 'create-actors',
+            before: 'ignore',
+            during: 'queue',
+            after: 'allow'
+        },
+        session: {
+            ...DefaultRule.session,
+            beforeReceiveFromApp: (
+                session: Session,
+                message: Message<Payloads.CreatePrimitive>
+            ) => {
+                session.cacheCreateActorMessage(message);
+                return message;
+            }
+        }
+    },
+
+    // ========================================================================
+    'create-from-prefab': {
+        ...DefaultRule,
+        handshake: {
+            during: 'ignore'
+        },
+        synchronization: {
+            stage: 'create-actors',
+            before: 'ignore',
+            during: 'queue',
+            after: 'allow'
+        },
+        session: {
+            ...DefaultRule.session,
+            beforeReceiveFromApp: (
+                session: Session,
+                message: Message<Payloads.CreateFromPrefab>
+            ) => {
+                session.cacheCreateActorMessage(message);
+                return message;
+            }
+        }
+    },
+
+    // ========================================================================
+    'destroy-actors': {
+        ...DefaultRule,
+        handshake: {
+            during: 'ignore'
+        },
+        synchronization: {
+            stage: 'create-actors',
+            before: 'ignore',
+            during: 'queue',
+            after: 'allow'
+        },
+        session: {
+            ...DefaultRule.session,
+            beforeReceiveFromApp: (
+                session: Session,
+                message: Message<Payloads.DestroyActors>
+            ) => {
+                for (const actorId of message.payload.actorIds) {
+                    delete session.actorSet[actorId];
+                }
+                return message;
+            }
+        }
+    },
+
+    // ========================================================================
+    'enable-collider': {
+        ...DefaultRule,
+        handshake: {
+            during: 'ignore'
+        },
+        synchronization: {
+            stage: 'create-actors',
+            before: 'ignore',
+            during: 'queue',
+            after: 'allow'
+        },
+        session: {
+            ...DefaultRule.session,
+            beforeReceiveFromApp: (
+                session: Session,
+                message: Message<Payloads.EnableCollider>
+            ) => {
+                const syncActor = session.actorSet[message.payload.actorId];
+                if (syncActor) {
+                    // Merge the new component into the existing actor.
+                    syncActor.created.message.payload.actor.collider =
+                        deepmerge(syncActor.created.message.payload.actor.collider || {}, message.payload.collider);
+                }
+                return undefined;
+            }
+        }
+    },
+
+    // ========================================================================
+    'enable-light': {
+        ...DefaultRule,
+        handshake: {
+            during: 'ignore'
+        },
+        synchronization: {
+            stage: 'create-actors',
+            before: 'ignore',
+            during: 'queue',
+            after: 'allow'
+        },
+        session: {
+            ...DefaultRule.session,
+            beforeReceiveFromApp: (
+                session: Session,
+                message: Message<Payloads.EnableLight>
+            ) => {
+                const syncActor = session.actorSet[message.payload.actorId];
+                if (syncActor) {
+                    // Merge the new component into the existing actor.
+                    syncActor.created.message.payload.actor.light =
+                        deepmerge(syncActor.created.message.payload.actor.light || {}, message.payload.light);
+                }
+                return message;
+            }
+        }
+    },
+
+    // ========================================================================
+    'enable-rigidbody': {
+        ...DefaultRule,
+        handshake: {
+            during: 'ignore'
+        },
+        synchronization: {
+            stage: 'create-actors',
+            before: 'ignore',
+            during: 'queue',
+            after: 'allow'
+        },
+        session: {
+            ...DefaultRule.session,
+            beforeReceiveFromApp: (
+                session: Session,
+                message: Message<Payloads.EnableRigidBody>
+            ) => {
+                const syncActor = session.actorSet[message.payload.actorId];
+                if (syncActor) {
+                    // Merge the new component into the existing actor.
+                    syncActor.created.message.payload.actor.rigidBody =
+                        deepmerge(syncActor.created.message.payload.actor.rigidBody || {}, message.payload.rigidBody);
+                }
+                return message;
+            }
+        }
+    },
+
+    // ========================================================================
+    'enable-text': {
+        ...DefaultRule,
+        handshake: {
+            during: 'ignore'
+        },
+        synchronization: {
+            stage: 'create-actors',
+            before: 'ignore',
+            during: 'queue',
+            after: 'allow'
+        },
+        session: {
+            ...DefaultRule.session,
+            beforeReceiveFromApp: (
+                session: Session,
+                message: Message<Payloads.EnableText>
+            ) => {
+                const syncActor = session.actorSet[message.payload.actorId];
+                if (syncActor) {
+                    // Merge the new component into the existing actor.
+                    syncActor.created.message.payload.actor.text =
+                        deepmerge(syncActor.created.message.payload.actor.text || {}, message.payload.text);
+                }
+                return message;
+            }
+        }
+    },
+
+    // ========================================================================
+    'engine2app-rpc': {
+        ...ClientOnlyRule
+    },
+
+    // ========================================================================
+    'handshake': {
+        ...ClientOnlyRule
+    },
+
+    // ========================================================================
+    'handshake-complete': {
+        ...ClientOnlyRule
+    },
+
+    // ========================================================================
+    'handshake-reply': {
+        ...DefaultRule,
+        handshake: {
+            during: 'allow'
+        },
+        synchronization: {
+            stage: 'always',
+            before: 'error',
+            during: 'error',
+            after: 'error'
+        }
+    },
+
+    // ========================================================================
+    'heartbeat': {
+        ...DefaultRule,
+        handshake: {
+            during: 'allow'
+        },
+        synchronization: {
+            stage: 'always',
+            before: 'allow',
+            during: 'allow',
+            after: 'allow',
+        },
+    },
+
+    // ========================================================================
+    'heartbeat-reply': {
+        ...ClientOnlyRule
+    },
+
+    // ========================================================================
+    'interpolate-actor': {
+        ...DefaultRule,
+        handshake: {
+            during: 'ignore'
+        },
+        synchronization: {
+            stage: 'create-animations',
+            before: 'ignore',
+            during: 'queue',
+            after: 'allow'
+        },
+        session: {
+            ...DefaultRule.session,
+            beforeReceiveFromApp: (
+                session: Session,
+                message: Message<Payloads.InterpolateActor>
+            ) => {
+                const syncActor = session.actorSet[message.payload.actorId];
+                if (syncActor) {
+                    syncActor.activeInterpolations = syncActor.activeInterpolations || [];
+                    syncActor.activeInterpolations.push(deepmerge({}, message.payload));
+                }
+                return message;
+            }
+        }
+    },
+
+    // ========================================================================
+    'load-assets': {
+        ...DefaultRule,
+        handshake: {
+            during: 'ignore'
+        },
+        synchronization: {
+            stage: 'load-assets',
+            before: 'ignore',
+            during: 'queue',
+            after: 'allow'
+        },
+        session: {
+            ...DefaultRule.session,
+            beforeReceiveFromApp: (
+                session: Session,
+                message: Message<Payloads.LoadAssets>
+            ) => {
+                session.cacheLoadAssetsMessage(message);
+                return message;
+            }
+        }
+    },
+
+    // ========================================================================
+    'look-at': {
+        ...DefaultRule,
+        handshake: {
+            during: 'queue'
+        },
+        synchronization: {
+            stage: 'create-actors',
+            before: 'queue',
+            during: 'queue',
+            after: 'allow'
+        }
+    },
+
+    // ========================================================================
+    'multi-operation-result': {
+        ...ClientOnlyRule
+    },
+
+    // ========================================================================
+    'object-spawned': {
+        ...ClientOnlyRule,
+        session: {
+            ...DefaultRule.session,
+            beforeReceiveFromClient: (
+                session: Session,
+                client: Client,
+                message: Message<Payloads.ObjectSpawned>
+            ) => {
+                // Check that this is the authoritative client.
+                if (client.authoritative) {
+                    // Create local representations of the actors.
+                    for (const spawned of message.payload.actors) {
+                        let syncActor = session.actorSet[spawned.id];
+                        if (!syncActor) {
+                            syncActor = session.actorSet[spawned.id] = {
+                                created: {
+                                    message: {
+                                        payload: {
+                                            actor: spawned
+                                        }
+                                    } as Message<Payloads.CreateActorCommon>
+                                }
+                            };
+                            syncActor.actorId = spawned.id;
+                        }
+                    }
+                    // Allow the message to propagate to the app.
+                    return message;
+                }
+            }
+        }
+    },
+
+    // ========================================================================
+    'operation-result': {
+        ...ClientOnlyRule,
+        session: {
+            ...DefaultRule.session,
+            beforeReceiveFromClient: (
+                session: Session,
+                client: Client,
+                message: Message<Payloads.OperationResult>
+            ) => {
+                if (client.authoritative) {
+                    // Allow the message to propagate to the app.
+                    return message;
+                }
+            }
+        }
+    },
+
+    // ========================================================================
+    'perform-action': {
+        ...ClientOnlyRule
+    },
+
+    // ========================================================================
+    'rigidbody-add-force': {
+        ...DefaultRule,
+        handshake: {
+            during: 'queue'
+        },
+        synchronization: {
+            stage: 'create-actors',
+            before: 'queue',
+            during: 'queue',
+            after: 'allow'
+        }
+    },
+
+    // ========================================================================
+    'rigidbody-add-force-at-position': {
+        ...DefaultRule,
+        handshake: {
+            during: 'queue'
+        },
+        synchronization: {
+            stage: 'create-actors',
+            before: 'queue',
+            during: 'queue',
+            after: 'allow'
+        }
+    },
+
+    // ========================================================================
+    'rigidbody-add-relative-torque': {
+        ...DefaultRule,
+        handshake: {
+            during: 'queue'
+        },
+        synchronization: {
+            stage: 'create-actors',
+            before: 'queue',
+            during: 'queue',
+            after: 'allow'
+        }
+    },
+
+    // ========================================================================
+    'rigidbody-add-torque': {
+        ...DefaultRule,
+        handshake: {
+            during: 'queue'
+        },
+        synchronization: {
+            stage: 'create-actors',
+            before: 'queue',
+            during: 'queue',
+            after: 'allow'
+        }
+    },
+
+    // ========================================================================
+    'rigidbody-commands': {
+        ...DefaultRule,
+        handshake: {
+            during: 'queue'
+        },
+        synchronization: {
+            stage: 'create-actors',
+            before: 'queue',
+            during: 'queue',
+            after: 'allow'
+        }
+    },
+
+    // ========================================================================
+    'rigidbody-move-position': {
+        ...DefaultRule,
+        handshake: {
+            during: 'queue'
+        },
+        synchronization: {
+            stage: 'create-actors',
+            before: 'queue',
+            during: 'queue',
+            after: 'allow'
+        }
+    },
+
+    // ========================================================================
+    'rigidbody-move-rotation': {
+        ...DefaultRule,
+        handshake: {
+            during: 'queue'
+        },
+        synchronization: {
+            stage: 'create-actors',
+            before: 'queue',
+            during: 'queue',
+            after: 'allow'
+        }
+    },
+
+    // ========================================================================
+    'set-animation-state': {
+        ...DefaultRule,
+        handshake: {
+            during: 'ignore'
+        },
+        synchronization: {
+            stage: 'create-animations',
+            before: 'ignore',
+            during: 'queue',
+            after: 'allow'
+        },
+        session: {
+            ...DefaultRule.session,
+            beforeReceiveFromApp: (
+                session: Session,
+                message: Message<Payloads.SetAnimationState>
+            ) => {
+                // If the app enabled or disabled the animation, update our local sync state to match.
+                if (message.payload.state.enabled !== undefined) {
+                    const syncActor = session.actorSet[message.payload.actorId];
+                    if (syncActor) {
+                        const animation = session.findAnimation(syncActor, message.payload.animationName);
+                        if (animation) {
+                            animation.enabled = message.payload.state.enabled;
+                        }
+                    }
+                }
+                return message;
+            },
+            beforeReceiveFromClient: (
+                session: Session,
+                client: Client,
+                message: Message<Payloads.SetAnimationState>
+            ) => {
+                // Check that this is the authoritative client.
+                if (client.authoritative) {
+                    // Check that the actor exists.
+                    const syncActor = session.actorSet[message.payload.actorId];
+                    if (syncActor) {
+                        // If the animation was disabled on the client, notify other clients and also
+                        // update our local sync state.
+                        if (message.payload.state.enabled !== undefined && !message.payload.state.enabled) {
+                            const createdAnimation = (syncActor.createdAnimations || []).filter(
+                                item => item.message.payload.animationName === message.payload.animationName).shift();
+                            if (createdAnimation) {
+                                createdAnimation.enabled = message.payload.state.enabled;
+                                // Propagate to other clients.
+                                session.sendToClients(message, client.id);
+                            }
+                            // Remove the completed interpolation.
+                            syncActor.activeInterpolations =
+                                (syncActor.activeInterpolations || []).filter(
+                                    item => item.animationName !== message.payload.animationName);
+                        }
+                    }
+                    // Allow the message to propagate to the app.
+                    return message;
+                }
+            }
+        }
+    },
+
+    // ========================================================================
+    'set-authoritative': {
+        ...DefaultRule,
+        handshake: {
+            during: 'error'
+        },
+        synchronization: {
+            stage: 'always',
+            before: 'error',
+            during: 'error',
+            after: 'error'
+        }
+    },
+
+    // ========================================================================
+    'set-behavior': {
+        ...DefaultRule,
+        handshake: {
+            during: 'ignore'
+        },
+        synchronization: {
+            stage: 'create-actors',
+            before: 'ignore',
+            during: 'queue',
+            after: 'allow'
+        },
+        session: {
+            ...DefaultRule.session,
+            beforeReceiveFromApp: (
+                session: Session,
+                message: Message<Payloads.SetBehavior>
+            ) => {
+                const syncActor = session.actorSet[message.payload.actorId];
+                if (syncActor) {
+                    syncActor.behavior = message.payload.behaviorType;
+                }
+                return message;
+            }
+        }
+    },
+
+    // ========================================================================
+    'sync-animations': {
+        ...DefaultRule,
+        handshake: {
+            during: 'error'
+        },
+        synchronization: {
+            stage: 'sync-animations',
+            before: 'error',
+            during: 'allow',
+            after: 'error'
+        }
+    },
+
+    // ========================================================================
+    'sync-complete': {
+        ...DefaultRule,
+        handshake: {
+            during: 'error'
+        },
+        synchronization: {
+            stage: 'always',
+            before: 'error',
+            during: 'error',
+            after: 'allow'
+        }
+    },
+
+    // ========================================================================
+    'sync-request': {
+        ...ClientOnlyRule
+    },
+
+    // ========================================================================
+    'traces': {
+        ...ClientOnlyRule
+    },
+
+    // ========================================================================
+    'update-subscriptions': {
+        ...DefaultRule,
+        handshake: {
+            during: 'ignore'
+        },
+        synchronization: {
+            stage: 'create-actors',
+            before: 'ignore',
+            during: 'queue',
+            after: 'allow'
+        },
+        session: {
+            ...DefaultRule.session,
+            beforeReceiveFromApp: (
+                session: Session,
+                message: Message<Payloads.UpdateSubscriptions>
+            ) => {
+                if (message.payload.ownerType === 'actor') {
+                    const syncActor = session.actorSet[message.payload.id];
+                    if (syncActor) {
+                        syncActor.created.message.payload.actor.subscriptions =
+                            syncActor.created.message.payload.actor.subscriptions.filter(
+                                subscription => message.payload.removes.indexOf(subscription) < 0);
+                        syncActor.created.message.payload.actor.subscriptions.push(
+                            ...message.payload.adds);
+                    }
+                    return message;
+                }
+            }
+        }
+    },
+
+    // ========================================================================
+    'user-joined': {
+        ...ClientOnlyRule,
+        session: {
+            ...ClientOnlyRule.session,
+            beforeReceiveFromClient: (
+                session: Session,
+                client: Client,
+                message: Message<Payloads.UserJoined>
+            ) => {
+                // Associate the client connection with the user id.
+                client.userId = message.payload.user.id;
+
+                // Add remote ip address to the joining user.
+                const props = message.payload.user.properties = message.payload.user.properties || {};
+                if (client.conn instanceof WebSocket && !props.remoteAddress) {
+                    props.remoteAddress = client.conn.remoteAddress;
+                }
+
+                return message;
+            }
+        }
+    },
+
+    // ========================================================================
+    'user-left': {
+        ...ClientOnlyRule
+    },
+
+    // ========================================================================
+    'user-update': {
+        ...ClientOnlyRule
+    }
+};

--- a/packages/sdk/src/adapters/multipeer/session.ts
+++ b/packages/sdk/src/adapters/multipeer/session.ts
@@ -5,21 +5,22 @@
 
 import deepmerge from 'deepmerge';
 import { EventEmitter } from 'events';
-import { Client, SessionExecution, SessionHandshake, SessionSync, SyncActor } from '.';
-import * as MRESDK from '../..';
+import { Client, MissingRule, Rules, SessionExecution, SessionHandshake, SessionSync, SyncActor } from '.';
+import { Connection, Message, UserLike } from '../..';
 import * as Protocols from '../../protocols';
 import * as Payloads from '../../types/network/payloads';
 
 /**
  * @hidden
- * Class for associating multiple client connections with a single app session
+ * Class for associating multiple client connections with a single app session.
  */
 export class Session extends EventEmitter {
     // tslint:disable:variable-name
     private _clientSet: { [id: string]: Client } = {};
     private _actorSet: { [id: string]: Partial<SyncActor> } = {};
-    private _assetSet: Array<MRESDK.Message<Payloads.LoadAssets>> = [];
-    private _userSet: { [id: string]: Partial<MRESDK.UserLike> } = {};
+    private _assets: Array<Message<Payloads.LoadAssets>> = [];
+    private _assetUpdateSet: { [id: string]: Partial<Payloads.AssetUpdate> } = {};
+    private _userSet: { [id: string]: Partial<UserLike> } = {};
     private _protocol: Protocols.Protocol;
     // tslint:enable:variable-name
 
@@ -28,15 +29,19 @@ export class Session extends EventEmitter {
     public get protocol() { return this._protocol; }
     public get clients() { return Object.keys(this._clientSet).map(clientId => this._clientSet[clientId]); }
     public get actors() { return Object.keys(this._actorSet).map(actorId => this._actorSet[actorId]); }
+    public get assets() { return this._assets; }
+    public get assetUpdates() {
+        return Object.keys(this._assetUpdateSet).map(assetId => this._assetUpdateSet[assetId]);
+    }
     public get rootActors() {
         return Object.keys(this._actorSet).filter(actorId =>
             !this._actorSet[actorId].created.message.payload.actor.parentId).map(actorId => this._actorSet[actorId]);
     }
-    public get assetSet() { return this._assetSet; }
     public get users() { return Object.keys(this._userSet).map(userId => this._userSet[userId]); }
     public get authoritativeClient() { return this.clients.sort((a, b) => a.order - b.order).shift(); }
     public get peerAuthoritative() { return this._peerAuthoritative; }
     public get actorSet() { return this._actorSet; }
+    public get assetUpdateSet() { return this._assetUpdateSet; }
     public get userSet() { return this._userSet; }
 
     public client = (clientId: string) => this._clientSet[clientId];
@@ -50,7 +55,7 @@ export class Session extends EventEmitter {
      * Creates a new Session instance
      */
     // tslint:disable-next-line:variable-name
-    constructor(private _conn: MRESDK.Connection, private _sessionId: string, private _peerAuthoritative: boolean) {
+    constructor(private _conn: Connection, private _sessionId: string, private _peerAuthoritative: boolean) {
         super();
         this.recvFromClient = this.recvFromClient.bind(this);
         this.recvFromApp = this.recvFromApp.bind(this);
@@ -101,7 +106,7 @@ export class Session extends EventEmitter {
         this._clientSet[client.id] = client;
         client.on('close', () => this.leave(client.id));
         await client.join(this);
-        client.on('recv', (_: Client, message: MRESDK.Message) => this.recvFromClient(client, message));
+        client.on('recv', (_: Client, message: Message) => this.recvFromClient(client, message));
         if (this.authoritativeClient) {
             this.authoritativeClient.sendPayload({
                 type: 'set-authoritative',
@@ -138,360 +143,112 @@ export class Session extends EventEmitter {
         }
     }
 
-    private recvFromClient = (client: Client, message: MRESDK.Message) => {
+    private recvFromClient = (client: Client, message: Message) => {
         message = this.preprocessFromClient(client, message);
         if (message) {
             this.sendToApp(message);
         }
     }
 
-    private recvFromApp = (message: MRESDK.Message) => {
+    private recvFromApp = (message: Message) => {
         message = this.preprocessFromApp(message);
         if (message) {
             this.sendToClients(message);
         }
     }
 
-    private preprocessFromApp(message: MRESDK.Message): MRESDK.Message {
-        message.payload = this.preprocessPayloadFromApp(message.payload, message);
-        return message.payload ? message : undefined;
+    public preprocessFromApp(message: Message): Message {
+        const rule = Rules[message.payload.type] || MissingRule;
+        const beforeReceiveFromApp = rule.session.beforeReceiveFromApp || (() => message);
+        return beforeReceiveFromApp(this, message);
     }
 
-    private preprocessPayloadFromApp(
-        payload: Partial<Payloads.Payload>,
-        message: MRESDK.Message): Partial<Payloads.Payload> {
-        const handler = (this as any)[`app-preprocess-${payload.type}`] || (() => payload);
-        return handler(payload, message);
-    }
-
-    private preprocessFromClient(client: Client, message: MRESDK.Message): MRESDK.Message {
+    public preprocessFromClient(client: Client, message: Message): Message {
+        // Precaution: If we don't recognize this client, drop the message.
         if (!this._clientSet[client.id]) {
             return undefined;
         }
         if (message.payload && message.payload.type && message.payload.type.length) {
-            const handler = (this as any)[`client-preprocess-${message.payload.type}`] || (() => message.payload);
-            message.payload = handler(client, message.payload);
+            const rule = Rules[message.payload.type] || MissingRule;
+            const beforeReceiveFromClient = rule.session.beforeReceiveFromClient || (() => message);
+            message = beforeReceiveFromClient(this, client, message);
         }
-        return message.payload ? message : undefined;
+        return message;
     }
 
-    private sendToApp(message: MRESDK.Message) {
+    public sendToApp(message: Message) {
         this.protocol.sendMessage(message);
     }
 
-    private sendToClients(message: MRESDK.Message, excludeId?: string) {
+    public sendToClients(message: Message, excludeId?: string) {
         const clients = this.clients.filter(client => client.id !== excludeId);
         for (const client of clients) {
             client.send({ ...message });
         }
     }
 
-    private sendPayloadToClients(payload: Partial<Payloads.Payload>, excludeId?: string) {
+    public sendPayloadToClients(payload: Partial<Payloads.Payload>, excludeId?: string) {
         const clients = this.clients.filter(client => client.id !== excludeId);
         for (const client of clients) {
             client.sendPayload({ ...payload });
         }
     }
 
-    private findAnimation(syncActor: Partial<SyncActor>, animationName: string) {
+    public findAnimation(syncActor: Partial<SyncActor>, animationName: string) {
         return (syncActor.createdAnimations || []).find(item => item.message.payload.animationName === animationName);
     }
 
-    private isAnimating(syncActor: Partial<SyncActor>) {
-        return !!(syncActor.createdAnimations || []).find(item => item.enabled);
+    public isAnimating(syncActor: Partial<SyncActor>): boolean {
+        if ((syncActor.createdAnimations || []).some(item => item.enabled)) {
+            return true;
+        }
+        if (syncActor.created &&
+            syncActor.created.message &&
+            syncActor.created.message.payload &&
+            syncActor.created.message.payload.actor) {
+            const parent = this._actorSet[syncActor.created.message.payload.actor.parentId];
+            if (parent) {
+                return this.isAnimating(parent);
+            }
+        }
+        return false;
     }
 
-    private createActor(payload: Payloads.CreateActorCommon, message: MRESDK.Message<Payloads.CreateActorCommon>) {
-        let syncActor = this.actorSet[payload.actor.id];
+    public cacheCreateActorMessage(message: Message<Payloads.CreateActorCommon>) {
+        let syncActor = this.actorSet[message.payload.actor.id];
         if (!syncActor) {
             const createActor = deepmerge({ message }, {});
-            syncActor = this.actorSet[payload.actor.id] = { created: createActor };
-            syncActor.actorId = payload.actor.id;
+            syncActor = this.actorSet[message.payload.actor.id] = { created: createActor };
+            syncActor.actorId = message.payload.actor.id;
         }
     }
 
-    /** @private */
-    public 'app-preprocess-create-animation' = (
-        payload: Payloads.CreateAnimation,
-        message: MRESDK.Message<Payloads.CreateAnimation>) => {
-        const syncActor = this.actorSet[payload.actorId];
+    public cacheActorUpdateMessage(message: Message<Payloads.ActorUpdate>) {
+        const syncActor = this.actorSet[message.payload.actor.id];
         if (syncActor) {
-            const enabled = message.payload.initialState && !!message.payload.initialState.enabled;
-            syncActor.createdAnimations = syncActor.createdAnimations || [];
-            syncActor.createdAnimations.push({ message, enabled });
-        }
-        return payload;
-    }
-
-    /** @private */
-    public 'app-preprocess-set-animation-state' = (payload: Payloads.SetAnimationState) => {
-        // If the app enabled or disabled the animation, update our local sync state to match.
-        if (payload.state.enabled !== undefined) {
-            const syncActor = this.actorSet[payload.actorId];
-            if (syncActor) {
-                const animation = this.findAnimation(syncActor, payload.animationName);
-                if (animation) {
-                    animation.enabled = payload.state.enabled;
-                }
-            }
-        }
-        return payload;
-    }
-
-    /** @private */
-    public 'app-preprocess-interpolate-actor' = (payload: Payloads.InterpolateActor) => {
-        const syncActor = this.actorSet[payload.actorId];
-        if (syncActor) {
-            syncActor.activeInterpolations = syncActor.activeInterpolations || [];
-            syncActor.activeInterpolations.push(deepmerge({}, payload));
-        }
-        return payload;
-    }
-
-    /** @private */
-    public 'app-preprocess-load-assets' = (
-        payload: Payloads.LoadAssets,
-        message: MRESDK.Message<Payloads.LoadAssets>) => {
-        this._assetSet.push(message);
-        return payload;
-    }
-
-    /** @private */
-    public 'app-preprocess-create-empty' = (
-        payload: Payloads.CreateEmpty,
-        message: MRESDK.Message<Payloads.CreateEmpty>) => {
-        this.createActor(payload, message);
-        return payload;
-    }
-
-    /** @private */
-    public 'app-preprocess-create-primitive' = (
-        payload: Payloads.CreatePrimitive,
-        message: MRESDK.Message<Payloads.CreatePrimitive>) => {
-        this.createActor(payload, message);
-        return payload;
-    }
-
-    /** @private */
-    public 'app-preprocess-create-from-gltf' = (
-        payload: Payloads.CreateFromGltf,
-        message: MRESDK.Message<Payloads.CreateFromGltf>) => {
-        this.createActor(payload, message);
-        return payload;
-    }
-
-    /** @private */
-    public 'app-preprocess-create-from-library' = (
-        payload: Payloads.CreateFromLibrary,
-        message: MRESDK.Message<Payloads.CreateFromLibrary>) => {
-        this.createActor(payload, message);
-        return payload;
-    }
-
-    /** @private */
-    public 'app-preprocess-create-from-prefab' = (
-        payload: Payloads.CreateFromPrefab,
-        message: MRESDK.Message<Payloads.CreateFromPrefab>) => {
-        this.createActor(payload, message);
-        return payload;
-    }
-
-    /** @private */
-    public 'app-preprocess-actor-update' = (payload: Payloads.ActorUpdate) => {
-        const syncActor = this.actorSet[payload.actor.id];
-        if (syncActor) {
-            // Merge the update into the existing actor
-            syncActor.created.message.payload.actor = deepmerge(syncActor.created.message.payload.actor, payload.actor);
-        }
-        return payload;
-    }
-
-    /** @private */
-    public 'app-preprocess-state-update' = (stateUpdate: Payloads.StateUpdate, message: MRESDK.Message) => {
-        const payloads: Array<Partial<Payloads.Payload>> = [];
-        for (let payload of stateUpdate.payloads) {
-            payload = this.preprocessPayloadFromApp(payload, message);
-            if (payload) {
-                payloads.push(payload);
-            }
-        }
-        stateUpdate.payloads = payloads;
-        return stateUpdate;
-    }
-
-    /** @private */
-    public 'app-preprocess-destroy-actors' = (payload: Payloads.DestroyActors) => {
-        for (const actorId of payload.actorIds) {
-            delete this._actorSet[actorId];
-        }
-        return payload;
-    }
-
-    /** @private */
-    public 'app-preprocess-enable-text' = (payload: Payloads.EnableText) => {
-        const syncActor = this.actorSet[payload.actorId];
-        if (syncActor) {
-            // Merge the new component into the existing actor
-            syncActor.created.message.payload.actor.text =
-                deepmerge(syncActor.created.message.payload.actor.text || {}, payload.text);
-        }
-        return payload;
-    }
-
-    /** @private */
-    public 'app-preprocess-enable-light' = (payload: Payloads.EnableLight) => {
-        const syncActor = this.actorSet[payload.actorId];
-        if (syncActor) {
-            // Merge the new component into the existing actor
-            syncActor.created.message.payload.actor.light =
-                deepmerge(syncActor.created.message.payload.actor.light || {}, payload.light);
-        }
-        return payload;
-    }
-
-    /** @private */
-    public 'app-preprocess-enable-rigidbody' = (payload: Payloads.EnableRigidBody) => {
-        const syncActor = this.actorSet[payload.actorId];
-        if (syncActor) {
-            // Merge the new component into the existing actor
-            syncActor.created.message.payload.actor.rigidBody =
-                deepmerge(syncActor.created.message.payload.actor.rigidBody || {}, payload.rigidBody);
-        }
-        return payload;
-    }
-
-    public 'app-preprocess-enable-collider' = (payload: Payloads.EnableCollider) => {
-        const syncActor = this.actorSet[payload.actorId];
-        if (syncActor) {
-            // Merge the new component into the existing actor
-            syncActor.created.message.payload.actor.collider =
-                deepmerge(syncActor.created.message.payload.actor.collider || {}, payload.collider);
+            // Merge the update into the existing actor.
+            syncActor.created.message.payload.actor
+                = deepmerge(syncActor.created.message.payload.actor, message.payload.actor);
+            return true;
         }
     }
 
-    /** @private */
-    public 'app-preprocess-app2engine-rpc' = (payload: Payloads.AppToEngineRPC) => {
-        // Send the message only to the specified user.
-        if (payload.userId) {
-            const client = this.clients.find(value => value.userId === payload.userId);
-            if (client) {
-                client.sendPayload(payload);
-            }
+    public cacheLoadAssetsMessage(message: Message<Payloads.LoadAssets>) {
+        // TODO: Is each load-asset unique? Can the same asset be loaded twice?
+        this.assets.push({ ...message });
+    }
+
+    public cacheAssetUpdateMessage(message: Message<Payloads.AssetUpdate>) {
+        let existing = this.assetUpdateSet[message.payload.asset.id];
+        if (!existing) {
+            existing = this.assetUpdateSet[message.payload.asset.id] = { ...message.payload };
         } else {
-            // If no user specified then allow the message to be sent to all users.
-            return payload;
-        }
-    }
-
-    /** @private */
-    public 'app-preprocess-set-behavior' = (payload: Payloads.SetBehavior) => {
-        const syncActor = this.actorSet[payload.actorId];
-        if (syncActor) {
-            syncActor.behavior = payload.behaviorType;
-        }
-        return payload;
-    }
-
-    public 'client-preprocess-operation-result' = (client: Client, payload: Payloads.OperationResult) => {
-        if (client.authoritative) {
-            // Allow the message to propagate to the app
-            return payload;
-        }
-    }
-
-    /** @private */
-    public 'client-preprocess-user-joined' = (client: Client, payload: Payloads.UserJoined) => {
-        // Associate the client connection with the user id.
-        client.userId = payload.user.id;
-
-        // add remote ip address to the joining user
-        const props = payload.user.properties = payload.user.properties || {};
-        if (client.conn instanceof MRESDK.WebSocket && !props.remoteAddress) {
-            props.remoteAddress = client.conn.remoteAddress;
-        }
-
-        return payload;
-    }
-
-    /** @private */
-    public 'client-preprocess-actor-update' = (client: Client, payload: Payloads.ActorUpdate) => {
-        // Check that this is the authoritative client
-        if (client.authoritative) {
-            // Check that the actor exists
-            const syncActor = this.actorSet[payload.actor.id];
-            if (syncActor) {
-                // Merge the update into the existing actor
-                syncActor.created.message.payload.actor =
-                    deepmerge(syncActor.created.message.payload.actor, payload.actor);
-                // Send the payload as an 'actor-correction' so that the change will be interpolated rather than
-                // applied immediately to the actor.
-                const actorCorrection = deepmerge(payload, {});
-                actorCorrection.type = 'actor-correction';
-                // If the actor is currently animating, then strip the transform from the update. Sending transform
-                // updates to other clients would break animations on those clients.
-                if (this.isAnimating(syncActor)) {
-                    actorCorrection.actor.transform = undefined;
-                }
-                // Sync the change to the other clients
-                this.sendPayloadToClients(actorCorrection, client.id);
-                // Allow the message to propagate to the app
-                // TODO: Only forward payload to the app if the app has registered subscriptions for this kind of
-                // update on this actor.
-                return payload;
-            }
-        }
-    }
-
-    /** @private */
-    public 'client-preprocess-object-spawned' = (client: Client, payload: Payloads.ObjectSpawned) => {
-        // Check that this is the authoritative client
-        if (client.authoritative) {
-            // Create local representations of the actors
-            for (const spawned of payload.actors) {
-                let syncActor = this.actorSet[spawned.id];
-                if (!syncActor) {
-                    syncActor = this._actorSet[spawned.id] = {
-                        created: {
-                            message: {
-                                payload: {
-                                    actor: spawned
-                                }
-                            } as MRESDK.Message<Payloads.CreateActorCommon>
-                        }
-                    };
-                    syncActor.actorId = spawned.id;
-                }
-            }
-            // Allow the message to propagate to the app.
-            return payload;
-        }
-    }
-
-    /** @private */
-    public 'client-preprocess-set-animation-state' = (client: Client, payload: Payloads.SetAnimationState) => {
-        // Check that this is the authoritative client
-        if (client.authoritative) {
-            // Check that the actor exists
-            const syncActor = this.actorSet[payload.actorId];
-            if (syncActor) {
-                // If the animation was disabled on the client, notify other clients and also
-                // update our local sync state.
-                if (payload.state.enabled !== undefined && !payload.state.enabled) {
-                    const createdAnimation = (syncActor.createdAnimations || []).filter(
-                        item => item.message.payload.animationName === payload.animationName).shift();
-                    if (createdAnimation) {
-                        createdAnimation.enabled = payload.state.enabled;
-                        // Propagate to other clients.
-                        this.sendPayloadToClients(payload, client.id);
-                    }
-                    // Remove the completed interpolation.
-                    syncActor.activeInterpolations =
-                        (syncActor.activeInterpolations || []).filter(
-                            item => item.animationName !== payload.animationName);
-                }
-            }
-            // Allow the message to propagate to the app.
-            return payload;
+            // Merge with existing message.
+            // TODO: Is this correct? This is purely additive.
+            existing = {
+                ...existing,
+                ...message.payload
+            };
         }
     }
 }

--- a/packages/sdk/src/adapters/multipeer/syncActor.ts
+++ b/packages/sdk/src/adapters/multipeer/syncActor.ts
@@ -3,21 +3,21 @@
  * Licensed under the MIT License.
  */
 
-import * as MRESDK from '../..';
+import { BehaviorType, Message } from '../..';
 import * as Payloads from '../../types/network/payloads';
 
 /**
  * @hidden
  */
 export type CreateActor = {
-    message: MRESDK.Message<Payloads.CreateActorCommon>;
+    message: Message<Payloads.CreateActorCommon>;
 };
 
 /**
  * @hidden
  */
 export type CreateAnimation = {
-    message: MRESDK.Message<Payloads.CreateAnimation>;
+    message: Message<Payloads.CreateAnimation>;
     enabled: boolean;
 };
 
@@ -29,5 +29,5 @@ export type SyncActor = {
     created: CreateActor;
     createdAnimations: CreateAnimation[];
     activeInterpolations: Payloads.InterpolateActor[];
-    behavior: MRESDK.BehaviorType;
+    behavior: BehaviorType;
 };

--- a/packages/sdk/src/connection/connection.ts
+++ b/packages/sdk/src/connection/connection.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { Message } from '../types/network';
+import { Message } from '..';
 import { ExponentialMovingAverage } from '../utils/exponentialMovingAverage';
 import { QueuedPromise } from '../utils/queuedPromise';
 import { TrackingClock } from '../utils/trackingClock';

--- a/packages/sdk/src/connection/nullConnection.ts
+++ b/packages/sdk/src/connection/nullConnection.ts
@@ -8,6 +8,7 @@ import { Connection, ConnectionQuality } from '.';
 import { Message } from '..';
 
 /**
+ * @hidden
  * A Connection that does performs nops for send and receive.
  */
 export class NullConnection extends EventEmitter implements Connection {

--- a/packages/sdk/src/connection/pipe.ts
+++ b/packages/sdk/src/connection/pipe.ts
@@ -7,6 +7,7 @@ import { Connection, EventedConnection } from '.';
 import { Message } from '..';
 
 /**
+ * @hidden
  * Class representing two connected endpoints, allowing them to send and receive to and from one another
  */
 export class Pipe {

--- a/packages/sdk/src/connection/webSocket.ts
+++ b/packages/sdk/src/connection/webSocket.ts
@@ -8,6 +8,7 @@ import { EventedConnection } from '.';
 import { Message } from '..';
 import filterEmpty from '../utils/filterEmpty';
 import validateJsonFieldName from '../utils/validateJsonFieldName';
+import { log } from './../log';
 
 /**
  * An implementation of the Connection interface that wraps a WebSocket.
@@ -41,7 +42,7 @@ export class WebSocket extends EventedConnection {
                     });
                 this._ws.send(json);
             } catch (e) {
-                this.emit('error', e);
+                log.error('network', e);
             }
         });
     }

--- a/packages/sdk/src/protocols/execution.ts
+++ b/packages/sdk/src/protocols/execution.ts
@@ -15,7 +15,6 @@ import {
     OperationResult,
     PerformAction,
     SetAnimationState,
-    StateUpdate,
     SyncRequest,
     Traces,
     UserJoined,
@@ -44,13 +43,6 @@ export class Execution extends Protocol {
     /** @private */
     public 'recv-object-spawned' = (payload: ObjectSpawned) => {
         this.emit('protocol.update-actors', payload.actors);
-    }
-
-    /** @private */
-    public 'recv-state-update' = (update: StateUpdate) => {
-        for (const payload of update.payloads) {
-            this.recvPayload(payload);
-        }
     }
 
     /** @private */

--- a/packages/sdk/src/protocols/protocol.ts
+++ b/packages/sdk/src/protocols/protocol.ts
@@ -100,13 +100,14 @@ export class Protocol extends EventEmitter {
 
     public recvPayload(payload: Partial<Payload>) {
         if (payload && payload.type && payload.type.length) {
-            // tslint:disable-next-line:no-any
             const handler = (this as any)[`recv-${payload.type}`] || (() => {
-                log.error('network', `${this.name} has no handler for payload ${payload.type}!`);
+                // tslint:disable-next-line:no-console
+                console.error(`[ERROR] ${this.name} has no handler for payload ${payload.type}!`);
             });
             handler(payload);
         } else {
-            log.error('network', `${this.name} invalid message payload!`);
+            // tslint:disable-next-line:no-console
+            console.error(`[ERROR] ${this.name} invalid message payload!`);
         }
     }
 
@@ -124,7 +125,8 @@ export class Protocol extends EventEmitter {
     protected handleReplyMessage(message: Message) {
         const queuedPromise = this.promises[message.replyToId];
         if (!queuedPromise) {
-            log.error('network', `${this.name} received unexpected reply message! replyToId: ${message.replyToId}`);
+            // tslint:disable-next-line:no-console
+            console.error(`[ERROR] ${this.name} received unexpected reply message! replyToId: ${message.replyToId}`);
         } else {
             delete this.promises[message.replyToId];
             queuedPromise.promise.resolve(message.payload, message);

--- a/packages/sdk/src/types/internal/context.ts
+++ b/packages/sdk/src/types/internal/context.ts
@@ -64,7 +64,6 @@ import {
     RigidBodyCommands,
     SetAnimationState,
     SetBehavior,
-    StateUpdate,
     UpdateCollisionEventSubscriptions,
     UpdateSubscriptions,
 } from '../network/payloads';
@@ -648,9 +647,6 @@ export class InternalContext {
 
         this.prevGeneration = this.generation;
 
-        // Build state diff payload array.
-        const payloads: any[] = [];
-
         const syncObjects = [
             ...Object.values(this.actorSet),
             ...Object.values(this.context.assetManager.assets)
@@ -663,29 +659,16 @@ export class InternalContext {
             }
 
             if (patchable instanceof Actor) {
-                payloads.push({
+                this.protocol.sendPayload({
                     type: 'actor-update',
                     actor: patch as ActorLike
                 } as ActorUpdate);
             } else if (patchable instanceof Asset) {
-                payloads.push({
+                this.protocol.sendPayload({
                     type: 'asset-update',
                     asset: patch as AssetLike
                 } as AssetUpdate);
             }
-        }
-
-        if (payloads.length) {
-            this.sendStateUpdate(payloads);
-        }
-    }
-
-    public sendStateUpdate(payloads: any[]) {
-        while (payloads.length) {
-            this.protocol.sendPayload({
-                type: 'state-update',
-                payloads: payloads.splice(0, 20)
-            } as StateUpdate);
         }
     }
 

--- a/packages/sdk/src/types/network/payloads/payloads.ts
+++ b/packages/sdk/src/types/network/payloads/payloads.ts
@@ -13,60 +13,56 @@ import { SubscriptionOwnerType, SubscriptionType } from '../subscriptionType';
 
 /**
  * @hidden
+ * *** KEEP ENTRIES SORTED ***
  */
 export type PayloadType
-    = 'traces'
-    | 'operation-result'
-    | 'multi-operation-result'
-    | 'handshake'
-    | 'handshake-reply'
-    | 'handshake-complete'
-    | 'heartbeat'
-    | 'heartbeat-reply'
+    = 'actor-correction'
+    | 'actor-update'
     | 'app2engine-rpc'
-    | 'engine2app-rpc'
-    | 'object-spawned'
-    | 'actor-update'
-    | 'destroy-actors'
-    | 'state-update'
-    | 'user-update'
-    | 'user-joined'
-    | 'user-left'
-    | 'perform-action'
-    | 'sync-request'
-    | 'create-from-library'
-    | 'create-from-gltf'
+    | 'asset-update'
+    | 'assets-loaded'
+    | 'create-animation'
     | 'create-empty'
-    | 'create-primitive'
+    | 'create-from-gltf'
+    | 'create-from-library'
     | 'create-from-prefab'
-    | 'actor-update'
-    | 'actor-correction'
+    | 'create-primitive'
     | 'destroy-actors'
-    | 'state-update'
-    | 'sync-complete'
-    | 'set-authoritative'
+    | 'enable-collider'
     | 'enable-light'
     | 'enable-rigidbody'
     | 'enable-text'
-    | 'update-subscriptions'
+    | 'engine2app-rpc'
+    | 'handshake'
+    | 'handshake-complete'
+    | 'handshake-reply'
+    | 'heartbeat'
+    | 'heartbeat-reply'
+    | 'interpolate-actor'
+    | 'load-assets'
+    | 'look-at'
+    | 'multi-operation-result'
+    | 'object-spawned'
+    | 'operation-result'
+    | 'perform-action'
+    | 'rigidbody-add-force'
+    | 'rigidbody-add-force-at-position'
+    | 'rigidbody-add-relative-torque'
+    | 'rigidbody-add-torque'
     | 'rigidbody-commands'
     | 'rigidbody-move-position'
     | 'rigidbody-move-rotation'
-    | 'rigidbody-add-force'
-    | 'rigidbody-add-force-at-position'
-    | 'rigidbody-add-torque'
-    | 'rigidbody-add-relative-torque'
-    | 'create-animation'
     | 'set-animation-state'
-    | 'sync-animations'
-    | 'interpolate-actor'
+    | 'set-authoritative'
     | 'set-behavior'
-    | 'set-primary-behavior'
-    | 'update-background-behaviors'
-    | 'load-assets'
-    | 'assets-loaded'
-    | 'asset-update'
-    | 'look-at'
+    | 'sync-animations'
+    | 'sync-complete'
+    | 'sync-request'
+    | 'traces'
+    | 'update-subscriptions'
+    | 'user-joined'
+    | 'user-left'
+    | 'user-update'
     ;
 
 /**
@@ -243,15 +239,6 @@ export type ActorUpdate = Payload & {
 export type DestroyActors = Payload & {
     type: 'destroy-actors';
     actorIds: string[];
-};
-
-/**
- * @hidden
- * Bi-directional. Envelope for multiple update and event payloads (ActorUpdate, etc).
- */
-export type StateUpdate = Payload & {
-    type: 'state-update';
-    payloads: Array<Partial<Payload>>;
 };
 
 /**


### PR DESCRIPTION
A clear pattern finally emerged in the way the multi-peer adapter handle's different kinds of network messages at various stages of handshake, join-in-progress, and regular operation.

This refactor formalizes that pattern, standardizing how message handling is configured for every payload type at different join stages. Comprehensive message handling "rules" are defined in a new file called 'rules.ts'.

The code is still complex, but hopefully more understandable and maintainable now.

Fixes: #110, #141, #130, the bug where the actor transform was always synced, and probably others.

This is a big PR. Review what you can.