### PR TITLE
[SDK] New version compatibility scheme

### DIFF
--- a/packages/sdk/package-lock.json
+++ b/packages/sdk/package-lock.json
@@ -106,6 +106,12 @@
         "@types/spdy": "*"
       }
     },
+    "@types/semver": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ==",
+      "dev": true
+    },
     "@types/shelljs": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.8.1.tgz",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -38,6 +38,7 @@
     "@types/deepmerge": "^2.1.0",
     "@types/query-string": "^6.1.1",
     "@types/restify": "^7.2.0",
+    "@types/semver": "^5.5.0",
     "@types/uuid": "^3.4.3",
     "@types/ws": "^6.0.1",
     "tslint": "5.11.0",
@@ -51,6 +52,7 @@
     "forwarded-for": "^1.0.1",
     "query-string": "^6.2.0",
     "restify": "^7.2.0",
+    "semver": "^5.6.0",
     "uuid": "^3.2.1",
     "ws": "^6.1.2"
   }

--- a/packages/sdk/src/adapters/multipeer/adapter.ts
+++ b/packages/sdk/src/adapters/multipeer/adapter.ts
@@ -11,7 +11,7 @@ import * as WS from 'ws';
 import { Adapter, AdapterOptions } from '..';
 import { Context, ParameterSet, Pipe, WebSocket } from '../../';
 import * as Constants from '../../constants';
-import { verifyClient } from '../../utils/verifyClient';
+import verifyClient from '../../utils/verifyClient';
 import { log } from './../../log';
 import { Client } from './client';
 import { Session } from './session';
@@ -114,7 +114,7 @@ export class MultipeerAdapter extends Adapter {
             log.info('network', "New Multi-peer connection");
 
             // Read the sessionId header.
-            let sessionId = request.headers[Constants.SessionHeader] as string || UUID();
+            let sessionId = request.headers[Constants.HTTPHeaders.SessionID] as string || UUID();
             sessionId = decodeURIComponent(sessionId);
 
             // Parse URL parameters.

--- a/packages/sdk/src/adapters/websocket/adapter.ts
+++ b/packages/sdk/src/adapters/websocket/adapter.ts
@@ -11,7 +11,7 @@ import * as WS from 'ws';
 import { Adapter, AdapterOptions } from '..';
 import { Context, WebSocket } from '../..';
 import * as Constants from '../../constants';
-import { verifyClient } from '../../utils/verifyClient';
+import verifyClient from '../../utils/verifyClient';
 import { log } from './../../log';
 
 /**
@@ -65,7 +65,7 @@ export class WebSocketAdapter extends Adapter {
             log.info('network', "New WebSocket connection");
 
             // Read the sessionId header.
-            let sessionId = request.headers[Constants.SessionHeader] as string || UUID();
+            let sessionId = request.headers[Constants.HTTPHeaders.SessionID] as string || UUID();
             sessionId = decodeURIComponent(sessionId);
 
             // Parse URL parameters.

--- a/packages/sdk/src/constants.ts
+++ b/packages/sdk/src/constants.ts
@@ -6,8 +6,10 @@
 // tslint:disable:variable-name
 
 /** @hidden */
-export const SessionHeader = 'x-ms-mixed-reality-extension-sessionid';
-/** @hidden */
-export const PlatformHeader = 'x-ms-mixed-reality-extension-platformid';
-/** @hidden */
-export const ProtocolVersionHeader = 'x-ms-mixed-reality-extension-protocol-version';
+export const HTTPHeaders = {
+    SessionID: 'x-ms-mixed-reality-extension-sessionid',
+    PlatformID: 'x-ms-mixed-reality-extension-platformid',
+    LegacyProtocolVersion: 'x-ms-mixed-reality-extension-protocol-version',
+    CurrentClientVersion: 'x-ms-mixed-reality-extension-client-version',
+    MinimumSupportedSDKVersion: 'x-ms-mixed-reality-extension-min-sdk-version',
+};

--- a/packages/sdk/src/utils/verifyClient.ts
+++ b/packages/sdk/src/utils/verifyClient.ts
@@ -61,14 +61,14 @@ export default function verifyClient(
         if (!clientPass) {
             // tslint:disable-next-line:max-line-length
             const message = `Connection rejected due to out of date client. Client version: ${CurrentClientVersion.toString()}. Min supported version by SDK: ${MinimumSupportedClientVersion.toString()}`;
-            log.info('network', message);
+            log.info('app', message);
             return cb(false, 403, message);
         }
 
         if (!sdkPass) {
             // tslint:disable-next-line:max-line-length
             const message = `Connection rejected due to out of date SDK. Current SDK version: ${CurrentSDKVersion.toString()}. Min supported version by client: ${MinimumSupportedSDKVersion.toString()}`;
-            log.info('network', message);
+            log.info('app', message);
             // Log this line to the console. The developer should know about this.
             // tslint:disable-next-line:no-console
             console.info(message);


### PR DESCRIPTION
Soren and I worked out a new version checking scheme: Client reports current client version and minimum supported SDK version. App checks this against minimum supported client version and current SDK version. If current client version >= minimum supported client version && current SDK version >= minimum supported SDK version, the connection is allowed.