### PR TITLE
AssetManager.createMaterial, createTexture, ready

### DIFF
--- a/packages/functional-tests/src/app.ts
+++ b/packages/functional-tests/src/app.ts
@@ -7,6 +7,7 @@ import * as MRESDK from '@microsoft/mixed-reality-extension-sdk';
 import * as MRERPC from '@microsoft/mixed-reality-extension-sdk/built/rpc';
 import AltspaceVRLibraryTest from './tests/altspacevr-library-test';
 import AltspaceVRVideoTest from './tests/altspacevr-video-test';
+import AssetEarlyAssignment from './tests/asset-early-assignment';
 import AssetPreloadTest from './tests/asset-preload-test';
 import ClockSyncTest from './tests/clock-sync-test';
 import GltfAnimationTest from './tests/gltf-animation-test';
@@ -44,6 +45,7 @@ export default class App {
     private testFactories: { [key: string]: (user: MRESDK.User) => Test } = {
         'altspacevr-library-test': (): Test => new AltspaceVRLibraryTest(this, this.baseUrl),
         'altspacevr-video-test': (): Test => new AltspaceVRVideoTest(this, this.baseUrl),
+        'asset-early-assignment': (): Test => new AssetEarlyAssignment(this, this.baseUrl),
         'asset-preload-test': (user: MRESDK.User): Test => new AssetPreloadTest(this, this.baseUrl, user),
         'clock-sync-test': (): Test => new ClockSyncTest(this, this.baseUrl),
         'gltf-animation-test': (): Test => new GltfAnimationTest(this, this.baseUrl),

--- a/packages/functional-tests/src/tests/asset-early-assignment.ts
+++ b/packages/functional-tests/src/tests/asset-early-assignment.ts
@@ -1,0 +1,65 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import * as GltfGen from '@microsoft/gltf-gen';
+import * as MRESDK from '@microsoft/mixed-reality-extension-sdk';
+
+import App from '../app';
+import Server from '../server';
+import delay from '../utils/delay';
+import destroyActors from '../utils/destroyActors';
+
+import Test from './test';
+
+export default class AssetEarlyAssignment extends Test {
+
+    constructor(app: App, private baseUrl: string) {
+        super(app);
+    }
+
+    public async run(): Promise<boolean> {
+        const AM = this.app.context.assetManager;
+
+        const label = MRESDK.Actor.CreateEmpty(this.app.context, {
+            actor: {
+                transform: {
+                    position: { x: 0, y: 2, z: 0 }
+                },
+                text: {
+                    contents: 'Colored & textured sphere',
+                    height: 0.3,
+                    anchor: MRESDK.TextAnchorLocation.BottomCenter
+                }
+            }
+        }).value;
+
+        const tex = AM.createTexture('uvgrid', {
+            uri: `${this.baseUrl}/uv-grid.png`
+        }).value;
+
+        const mat = AM.createMaterial('blue', {
+            color: MRESDK.Color3.Blue().toJSON(),
+            mainTextureId: tex.id
+        }).value;
+
+        const sphere = MRESDK.Actor.CreatePrimitive(this.app.context, {
+            definition: {
+                shape: MRESDK.PrimitiveShape.Sphere,
+                radius: 1
+            },
+            actor: {
+                materialId: mat.id,
+                transform: {
+                    position: { x: 0, y: 1, z: 0 }
+                }
+            }
+        }).value;
+
+        await delay(3000);
+
+        destroyActors([sphere, label]);
+        return true;
+    }
+}

--- a/packages/sdk/src/adapters/multipeer/rules.ts
+++ b/packages/sdk/src/adapters/multipeer/rules.ts
@@ -423,6 +423,27 @@ export const Rules: { [id in Payloads.PayloadType]: Rule } = {
     },
 
     // ========================================================================
+    'create-asset': {
+        ...DefaultRule,
+        synchronization: {
+            stage: 'load-assets',
+            before: 'ignore',
+            during: 'queue',
+            after: 'allow'
+        },
+        session: {
+            ...DefaultRule.session,
+            beforeReceiveFromApp: (
+                session: Session,
+                message: Message<Payloads.CreateAsset>
+            ) => {
+                session.cacheAssetCreationMessage(message);
+                return message;
+            }
+        }
+    },
+
+    // ========================================================================
     'create-empty': {
         ...DefaultRule,
         synchronization: {
@@ -736,7 +757,7 @@ export const Rules: { [id in Payloads.PayloadType]: Rule } = {
                 session: Session,
                 message: Message<Payloads.LoadAssets>
             ) => {
-                session.cacheLoadAssetsMessage(message);
+                session.cacheAssetCreationMessage(message);
                 return message;
             }
         }

--- a/packages/sdk/src/adapters/multipeer/session.ts
+++ b/packages/sdk/src/adapters/multipeer/session.ts
@@ -19,7 +19,7 @@ export class Session extends EventEmitter {
     // tslint:disable:variable-name
     private _clientSet: { [id: string]: Client } = {};
     private _actorSet: { [id: string]: Partial<SyncActor> } = {};
-    private _assets: Array<Message<Payloads.LoadAssets>> = [];
+    private _assets: Array<Message<Payloads.LoadAssets | Payloads.CreateAsset>> = [];
     private _assetUpdateSet: { [id: string]: Partial<Payloads.AssetUpdate> } = {};
     private _userSet: { [id: string]: Partial<UserLike> } = {};
     private _protocol: Protocols.Protocol;
@@ -242,7 +242,7 @@ export class Session extends EventEmitter {
         }
     }
 
-    public cacheLoadAssetsMessage(message: Message<Payloads.LoadAssets>) {
+    public cacheAssetCreationMessage(message: Message<Payloads.LoadAssets | Payloads.CreateAsset>) {
         // TODO: Is each load-asset unique? Can the same asset be loaded twice?
         this.assets.push({ ...message });
     }

--- a/packages/sdk/src/types/network/payloads/assets.ts
+++ b/packages/sdk/src/types/network/payloads/assets.ts
@@ -9,18 +9,20 @@ import { AssetLike, AssetSource } from '../../runtime/assets';
 
 export type CreateColliderType = ColliderType | 'none';
 
-/**
- * @hidden
- */
+/** @hidden */
 export type LoadAssets = Payload & {
     type: 'load-assets';
     source: AssetSource;
     colliderType: CreateColliderType;
 };
 
-/**
- * @hidden
- */
+/** @hidden */
+export type CreateAsset = Payload & {
+    type: 'create-asset';
+    definition: AssetLike;
+};
+
+/** @hidden */
 export type AssetsLoaded = Payload & {
     type: 'assets-loaded';
     assets: AssetLike[];
@@ -33,9 +35,7 @@ export type AssetUpdate = Payload & {
     asset: Partial<AssetLike>;
 };
 
-/**
- * @hidden
- */
+/** @hidden */
 export type CreateFromPrefab = CreateActorCommon & {
     type: 'create-from-prefab';
     prefabId: string;

--- a/packages/sdk/src/types/network/payloads/payloads.ts
+++ b/packages/sdk/src/types/network/payloads/payloads.ts
@@ -22,6 +22,7 @@ export type PayloadType
     | 'asset-update'
     | 'assets-loaded'
     | 'create-animation'
+    | 'create-asset'
     | 'create-empty'
     | 'create-from-gltf'
     | 'create-from-library'

--- a/packages/sdk/src/types/runtime/assets/asset.ts
+++ b/packages/sdk/src/types/runtime/assets/asset.ts
@@ -52,7 +52,7 @@ export interface AssetLike {
 }
 
 /** The base class for all asset types. */
-export class Asset implements AssetLike {
+export abstract class Asset implements AssetLike {
     // tslint:disable:variable-name
     private _id: string;
     private _name: string;

--- a/packages/sdk/src/types/runtime/assets/asset.ts
+++ b/packages/sdk/src/types/runtime/assets/asset.ts
@@ -42,13 +42,13 @@ export interface AssetLike {
     source?: AssetSource;
 
     /** Only populated when this asset is a prefab. An asset will have only one of these types specified. */
-    prefab?: PrefabLike;
+    prefab?: Partial<PrefabLike>;
     /** Only populated when this asset is a mesh. An asset will have only one of these types specified. */
-    mesh?: MeshLike;
+    mesh?: Partial<MeshLike>;
     /** Only populated when this asset is a material. An asset will have only one of these types specified. */
-    material?: MaterialLike;
+    material?: Partial<MaterialLike>;
     /** Only populated when this asset is a texture. An asset will have only one of these types specified. */
-    texture?: TextureLike;
+    texture?: Partial<TextureLike>;
 }
 
 /** The base class for all asset types. */
@@ -68,7 +68,7 @@ export class Asset implements AssetLike {
     /** @inheritdoc */
     public get source() { return this._source; }
 
-    protected constructor(public manager: AssetManager, def: AssetLike) {
+    protected constructor(public manager: AssetManager, def: Partial<AssetLike>) {
         this._id = def.id;
         this._name = def.name;
         this._source = def.source;
@@ -84,12 +84,14 @@ export class Asset implements AssetLike {
     }
 
     /** @hidden */
-    protected copy(from: Partial<AssetLike>): void {
+    public copy(from: Partial<AssetLike>): this {
         // tslint:disable:curly
         if (from.id) this._id = from.id;
         if (from.name) this._name = from.name;
         if (from.source) this._source = from.source;
         // tslint:enable:curly
+
+        return this;
     }
 
     /** @hidden */

--- a/packages/sdk/src/types/runtime/assets/assetManager.ts
+++ b/packages/sdk/src/types/runtime/assets/assetManager.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { Asset, AssetGroup } from '.';
+import { Asset, AssetGroup, Material, MaterialLike, Texture, TextureLike } from '.';
 import { Context } from '..';
 import { AssetsLoaded, CreateColliderType, LoadAssets } from '../../network/payloads';
 
@@ -52,6 +52,14 @@ export class AssetManager {
                     .catch(e => decrementRefsAndTest(true));
             }
         });
+    }
+
+    public createMaterial(groupName: string, definition: Partial<MaterialLike>): Promise<Material> {
+
+    }
+
+    public createTexture(groupName: string, uri: string, definition?: Partial<TextureLike>): Promise<Texture> {
+
     }
 
     /**

--- a/packages/sdk/src/types/runtime/assets/material.ts
+++ b/packages/sdk/src/types/runtime/assets/material.ts
@@ -91,6 +91,7 @@ export class Material extends Asset implements MaterialLike, Patchable<AssetLike
     /** @inheritdoc */
     public get material(): MaterialLike { return this; }
 
+    /** @hidden */
     public constructor(manager: AssetManager, def: AssetLike) {
         super(manager, def);
 
@@ -108,6 +109,10 @@ export class Material extends Asset implements MaterialLike, Patchable<AssetLike
         observe(this._color, 'color', (...path: string[]) => this.materialChanged(...path));
         observe(this._mainTextureOffset, 'mainTextureOffset', (...path: string[]) => this.materialChanged(...path));
         observe(this._mainTextureScale, 'mainTextureScale', (...path: string[]) => this.materialChanged(...path));
+    }
+
+    public static Create(manager: AssetManager, groupName: string, def: MaterialLike): Promise<Material> {
+        return manager.createMaterial(groupName, def);
     }
 
     public copy(from: Partial<AssetLike>): this {

--- a/packages/sdk/src/types/runtime/assets/material.ts
+++ b/packages/sdk/src/types/runtime/assets/material.ts
@@ -91,7 +91,7 @@ export class Material extends Asset implements MaterialLike, Patchable<AssetLike
     /** @inheritdoc */
     public get material(): MaterialLike { return this; }
 
-    /** @hidden */
+    /** INTERNAL USE ONLY. To create a new material from scratch, use [[AssetManager.createMaterial]]. */
     public constructor(manager: AssetManager, def: AssetLike) {
         super(manager, def);
 
@@ -99,20 +99,24 @@ export class Material extends Asset implements MaterialLike, Patchable<AssetLike
             throw new Error("Cannot construct material from non-material definition");
         }
 
-        this._color.copy(def.material.color);
-        this._mainTextureId = def.material.mainTextureId;
-        this._mainTextureOffset.copy(def.material.mainTextureOffset);
-        this._mainTextureScale.copy(def.material.mainTextureScale);
+        if (def.material.color) {
+            this._color.copy(def.material.color);
+        }
+        if (def.material.mainTextureId) {
+            this._mainTextureId = def.material.mainTextureId;
+        }
+        if (def.material.mainTextureOffset) {
+            this._mainTextureOffset.copy(def.material.mainTextureOffset);
+        }
+        if (def.material.mainTextureScale) {
+            this._mainTextureScale.copy(def.material.mainTextureScale);
+        }
 
         // material patching: observe the nested material properties
         // for changed values, and write them to a patch
         observe(this._color, 'color', (...path: string[]) => this.materialChanged(...path));
         observe(this._mainTextureOffset, 'mainTextureOffset', (...path: string[]) => this.materialChanged(...path));
         observe(this._mainTextureScale, 'mainTextureScale', (...path: string[]) => this.materialChanged(...path));
-    }
-
-    public static Create(manager: AssetManager, groupName: string, def: MaterialLike): Promise<Material> {
-        return manager.createMaterial(groupName, def);
     }
 
     public copy(from: Partial<AssetLike>): this {

--- a/packages/sdk/src/types/runtime/assets/mesh.ts
+++ b/packages/sdk/src/types/runtime/assets/mesh.ts
@@ -26,6 +26,7 @@ export class Mesh extends Asset implements MeshLike {
     /** @inheritdoc */
     public get mesh(): MeshLike { return this; }
 
+    /** @hidden */
     public constructor(manager: AssetManager, def: AssetLike) {
         super(manager, def);
 

--- a/packages/sdk/src/types/runtime/assets/prefab.ts
+++ b/packages/sdk/src/types/runtime/assets/prefab.ts
@@ -27,6 +27,7 @@ export class Prefab extends Asset implements PrefabLike, Patchable<AssetLike> {
     /** @inheritdoc */
     public get prefab(): PrefabLike { return this; }
 
+    /** @hidden */
     public constructor(manager: AssetManager, def: AssetLike) {
         super(manager, def);
 

--- a/packages/sdk/src/types/runtime/assets/texture.ts
+++ b/packages/sdk/src/types/runtime/assets/texture.ts
@@ -64,9 +64,18 @@ export class Texture extends Asset implements TextureLike, Patchable<AssetLike> 
             throw new Error("Cannot construct texture from non-texture definition");
         }
 
-        this._resolution = new Vector2(def.texture.resolution.x, def.texture.resolution.y);
-        this._wrapU = def.texture.wrapU;
-        this._wrapV = def.texture.wrapV;
+        if (def.texture.uri) {
+            this._uri = def.texture.uri;
+        }
+        if (def.texture.resolution) {
+            this._resolution = new Vector2(def.texture.resolution.x, def.texture.resolution.y);
+        }
+        if (def.texture.wrapU) {
+            this._wrapU = def.texture.wrapU;
+        }
+        if (def.texture.wrapV) {
+            this._wrapV = def.texture.wrapV;
+        }
     }
 
     public copy(from: Partial<AssetLike>): this {
@@ -80,6 +89,8 @@ export class Texture extends Asset implements TextureLike, Patchable<AssetLike> 
 
         // tslint:disable:curly
         super.copy(from);
+        if (from.texture && from.texture.uri)
+            this._uri = from.texture.uri;
         if (from.texture && from.texture.resolution)
             this._resolution = new Vector2(from.texture.resolution.x, from.texture.resolution.y);
         if (from.texture && from.texture.wrapU)
@@ -97,6 +108,7 @@ export class Texture extends Asset implements TextureLike, Patchable<AssetLike> 
         return {
             ...super.toJSON(),
             texture: {
+                uri: this.uri,
                 resolution: this.resolution.toJSON(),
                 wrapU: this.wrapU,
                 wrapV: this.wrapV

--- a/packages/sdk/src/types/runtime/assets/texture.ts
+++ b/packages/sdk/src/types/runtime/assets/texture.ts
@@ -11,6 +11,7 @@ import { InternalAsset } from '../../internal/asset';
 import { Patchable } from '../../patchable';
 
 export interface TextureLike {
+    uri?: string;
     resolution: Vector2Like;
     wrapU: TextureWrapMode;
     wrapV: TextureWrapMode;
@@ -28,6 +29,7 @@ export enum TextureWrapMode {
 
 export class Texture extends Asset implements TextureLike, Patchable<AssetLike> {
     // tslint:disable:variable-name
+    private _uri: string;
     private _resolution = Vector2.One();
     private _wrapU = TextureWrapMode.Repeat;
     private _wrapV = TextureWrapMode.Repeat;
@@ -36,6 +38,9 @@ export class Texture extends Asset implements TextureLike, Patchable<AssetLike> 
 
     /** @hidden */
     public get internal() { return this._internal; }
+
+    /** The URI, if any, this texture was loaded from */
+    public get uri() { return this._uri; }
 
     /** The pixel dimensions of the loaded texture */
     public get resolution() { return this._resolution; }
@@ -51,7 +56,7 @@ export class Texture extends Asset implements TextureLike, Patchable<AssetLike> 
     /** @inheritdoc */
     public get texture(): TextureLike { return this; }
 
-    /** @hidden */
+    /** INTERNAL USE ONLY. To load a new texture from scratch, use [[AssetManager.loadTexture]] */
     public constructor(manager: AssetManager, def: AssetLike) {
         super(manager, def);
 
@@ -62,10 +67,6 @@ export class Texture extends Asset implements TextureLike, Patchable<AssetLike> 
         this._resolution = new Vector2(def.texture.resolution.x, def.texture.resolution.y);
         this._wrapU = def.texture.wrapU;
         this._wrapV = def.texture.wrapV;
-    }
-
-    public static Create(manager: AssetManager, groupName: string, uri: string, def?: Partial<TextureLike>): Promise<Texture> {
-        return manager.createTexture(groupName, uri, def);
     }
 
     public copy(from: Partial<AssetLike>): this {

--- a/packages/sdk/src/types/runtime/assets/texture.ts
+++ b/packages/sdk/src/types/runtime/assets/texture.ts
@@ -51,6 +51,7 @@ export class Texture extends Asset implements TextureLike, Patchable<AssetLike> 
     /** @inheritdoc */
     public get texture(): TextureLike { return this; }
 
+    /** @hidden */
     public constructor(manager: AssetManager, def: AssetLike) {
         super(manager, def);
 
@@ -61,6 +62,10 @@ export class Texture extends Asset implements TextureLike, Patchable<AssetLike> 
         this._resolution = new Vector2(def.texture.resolution.x, def.texture.resolution.y);
         this._wrapU = def.texture.wrapU;
         this._wrapV = def.texture.wrapV;
+    }
+
+    public static Create(manager: AssetManager, groupName: string, uri: string, def?: Partial<TextureLike>): Promise<Texture> {
+        return manager.createTexture(groupName, uri, def);
     }
 
     public copy(from: Partial<AssetLike>): this {


### PR DESCRIPTION
* Make the asset constuctors take partials, and safely handle missing values.
* Add a `uri` field to `TextureLike`s for tracking texture sources separately from asset group sources.
* Refactor `AssetManager.ready` to be a promise chain instead of a dynamically created Promise.all call. New loads simply append their load to the chain. This dramatically reduces the complexity of the system.
* Added a default "manual" asset group that contains all individually created assets.
* Add `AssetManager.createMaterial(name: string, definition: MaterialLike): ForwardPromise<Material>`
* Add `AssetManager.createTexture(name: string, definition: TextureLike): ForwardPromise<Texture>`