### PR TITLE
[NOT FOR MERGE] Proposed Attachment API

### DIFF
--- a/packages/functional-tests/src/tests/hat-test.ts
+++ b/packages/functional-tests/src/tests/hat-test.ts
@@ -1,0 +1,61 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import * as MRESDK from '@microsoft/mixed-reality-extension-sdk';
+import App from '../app';
+import delay from '../utils/delay';
+import destroyActors from '../utils/destroyActors';
+import Test from './test';
+
+// tslint:disable:no-string-literal
+
+export default class HatTest extends Test {
+    private sceneRoot: MRESDK.Actor;
+    private running = true;
+
+    private hatNames = ['wizardhat', 'strawhat', 'tophat', 'LavaHelmet', 'redhat', 'hardhat'];
+    private modelScaleFactor = 1 / 60;
+
+    constructor(app: App, private baseUrl: string) {
+        super(app);
+    }
+
+    public async run() {
+        this.sceneRoot = MRESDK.Actor.CreateEmpty(this.app.context).value;
+        const runningTestPromise = this.runTest();
+        const timeout = setTimeout(() => this.running = false, 60000);
+        await runningTestPromise;
+        clearTimeout(timeout);
+        return true;
+    }
+
+    private async runTest() {
+        // Wear some hats!
+        while (this.running) {
+            // Show a menu of hats for selection. Return the name of the selected hat and the user that selected it.
+            const { hatName, user } = await this.selectHat();
+            if (hatName) {
+                // Create the selected hat.
+                const hat = this.createHat(hatName);
+                // Attach hat to avatar and wait five seconds. Feel free to walk around in your new hat!
+                hat.attach(user, 'head');
+                await delay(5000, this.running);
+                // Detach hat and wait another five seconds.
+                hat.detach();
+                await delay(5000, this.running);
+                // Destroy the hat.
+                destroyActors(hat);
+            }
+        }
+    }
+
+    private async selectHat(): Promise<{ hatName?: string, user?: MRESDK.User }> {
+        return {};
+    }
+
+    private createHat(hatName: string): MRESDK.Actor {
+        return undefined;
+    }
+}

--- a/packages/sdk/src/types/runtime/attachment.ts
+++ b/packages/sdk/src/types/runtime/attachment.ts
@@ -3,21 +3,80 @@
  * Licensed under the MIT License.
  */
 
-import { User } from '.';
+import { ZeroGuid } from "../../constants";
 
+/**
+ * The complete set of attach points.
+ */
+export type AttachPoint
+    = 'none'
+    | 'camera'
+    | 'head'
+    | 'neck'
+    | 'spine'
+    | 'hips'
+    | 'foot'
+    | 'toes'
+    | 'left-eye'
+    | 'left-upper-leg'
+    | 'left-lower-leg'
+    | 'left-shoulder'
+    | 'left-upper-arm'
+    | 'left-lower-arm'
+    | 'left-hand'
+    | 'left-thumb'
+    | 'left-index'
+    | 'left-middle'
+    | 'left-ring'
+    | 'left-pinky'
+    | 'right-eye'
+    | 'right-upper-leg'
+    | 'right-lower-leg'
+    | 'right-shoulder'
+    | 'right-upper-arm'
+    | 'right-lower-arm'
+    | 'right-hand'
+    | 'right-thumb'
+    | 'right-index'
+    | 'right-middle'
+    | 'right-ring'
+    | 'right-pinky'
+    ;
+
+/**
+ * The characteristics of an active attachment.
+ */
 export interface AttachmentLike {
-    attachPoint: string;
-    actorId: string;
+    userId: string;
+    attachPoint: AttachPoint;
 }
 
-export class Attachment {
+/**
+ * Implementation of AttachmentLike. This class is observable.
+ */
+export class Attachment implements AttachmentLike {
     // tslint:disable:variable-name
-    private _attachPoint: string;
-    private _actorId: string;
+    private _userId = ZeroGuid;
+    private _attachPoint: AttachPoint = 'none';
     // tslint:enable:variable-name
 
+    public get userId() { return this._userId; }
+    public set userId(value) { this._userId = value || ZeroGuid; }
     public get attachPoint() { return this._attachPoint; }
-    public get actor() { return this.user.context.actor(this._actorId); }
+    public set attachPoint(value) { this._attachPoint = value || 'none'; }
 
-    constructor(private user: User) { }
+    /** @hidden */
+    public toJSON(): AttachmentLike {
+        return {
+            userId: this.userId,
+            attachPoint: this.attachPoint
+        } as AttachmentLike;
+    }
+
+    public copy(from: Partial<AttachmentLike>): this {
+        if (!from) return this;
+        if (from.userId) this._userId = from.userId;
+        if (from.attachPoint) this._attachPoint = from.attachPoint;
+        return this;
+    }
 }

--- a/packages/sdk/src/types/runtime/index.ts
+++ b/packages/sdk/src/types/runtime/index.ts
@@ -8,7 +8,7 @@ export * from './behaviors';
 export * from './context';
 export * from './transform';
 export * from './user';
-// export * from './attachment';
+export * from './attachment';
 export * from './light';
 export * from './rigidbody';
 export * from './text';


### PR DESCRIPTION
Hey team, please review my proposed attachment API. This PR is for discussion only and won't be merged. Looking forward to your input.

#### notes
* Attach point names are based on what is currently available in Altspace. It all seemed reasonable for VR/MR.
* I added an attach point called 'camera' to handle cockpit space. It will require special handling client side. More detail below.
* The proposed implementation leverages the existing actor patching mechanism, so no new network payloads were needed. This is the model I want us to follow as much as possible going forward, since it requires no changes in the synchronization layer to add new features. Managing complexity in the sync layer should be an ever-present design constraint for us now that the architecture is in a good place.

The Node API is pretty simple. Most of the complexity will be client side. Some specifics:

#### 'camera' attach point
This is a special attach point that maps to the Altspace 'cockpit', which isn't exactly a camera. Maybe we should call it 'hud'. Regardless, objects attached to this location along with their children are automatically put into a user-local "desynchronized" state, meaning they're only shown to the user they're attached to, like a HUD element. *I don't think we can implement the 'camera' attach point until player masking or the user-local objects feature is in.*

#### avatar attach points
When an actor is attached to an avatar attach point, they are automatically unparented from any parent object and reparented to the avatar skeleton at the mapped location. Local transform is preserved. From the app's perspective the object no longer has a parent, since the skeleton is not reflected in the MRE's app state.

#### attachment lifecycle
Open question: When a user exits the world, what should happen to attached actors? My current thinking: Delete all objects attached to the 'camera' attach point (true for all user-local actors). Pass remaining attached actors as a parameter to the `onUserLeft` event callback, providing the app the opportunity to take action on them: destroy them, put them back in inventory, app-specific etc. Alternately: create a new `onActorDetached` event.

#### parenting
If an attached actor is parented to another object in the scene, it becomes detached. If a user-local object is parented to a shared object, it will be as if an unstoppable force met an immovable object.

#### demo
See hat-test.ts in files. The old SDK has an example involving hat attachments. In the same spirit, hat-test.ts illustrates how hat attachments could work in the new SDK.

#### examples
##### Spawn at attach point
We don't want to have to spawn an object and then attach it. This would result in an object appearing in-world then jumping to the attach location. This would be especially bad for the 'camera' attach point, where the object would briefly appear then disappear. Using the actor template we can spawn and attach simultaneously:
```ts
const hat = Actor.CreateFromPrefab(this.context, {
    prefabId: hatPrefab.id,
    actor: {
        attachment: {
            userId: user.id,
            attachPoint: 'head'
        },
        transform: {
            position:  { y: 1 }
        }
    }
}).value;
```

// other examples go here //