### PR TITLE
[SDK] Minor fix to animation sync

### DIFF
--- a/packages/sdk/src/adapters/multipeer/protocols/clientSync.ts
+++ b/packages/sdk/src/adapters/multipeer/protocols/clientSync.ts
@@ -209,9 +209,9 @@ export class ClientSync extends Protocols.Protocol {
                         // client, now pass it to the joining client.
                         for (const animationState of payload.animationStates) {
                             // Account for latency on the authoritative peer's connection.
-                            animationState.animationTime += authoritativeClient.conn.quality.latencyMs.value / 2000;
+                            animationState.state.time += authoritativeClient.conn.quality.latencyMs.value / 2000;
                             // Account for latency on the joining peer's connection.
-                            animationState.animationTime += this.conn.quality.latencyMs.value / 2000;
+                            animationState.state.time += this.conn.quality.latencyMs.value / 2000;
                         }
                         super.sendPayload(payload);
                         resolve();

--- a/packages/sdk/src/protocols/protocol.ts
+++ b/packages/sdk/src/protocols/protocol.ts
@@ -64,7 +64,7 @@ export class Protocol extends EventEmitter {
     }
 
     public startListening() {
-        log.verbose('network', `${this.name} started listening`);
+        log.debug('network', `${this.name} started listening`);
         this.conn.on('recv', this.onReceive);
         this.conn.on('close', this.onClose);
     }
@@ -72,7 +72,7 @@ export class Protocol extends EventEmitter {
     public stopListening() {
         this.conn.off('recv', this.onReceive);
         this.conn.off('close', this.onClose);
-        log.verbose('network', `${this.name} stopped listening`);
+        log.debug('network', `${this.name} stopped listening`);
     }
 
     public sendPayload(payload: Partial<Payload>, promise?: ExportedPromise) {
@@ -181,8 +181,8 @@ export class Protocol extends EventEmitter {
     protected handleReplyMessage(message: Message) {
         const queuedPromise = this.promises[message.replyToId];
         if (!queuedPromise) {
-            // tslint:disable-next-line:no-console
-            console.error(`[ERROR] ${this.name} received unexpected reply message! replyToId: ${message.replyToId}`);
+            // tslint:disable-next-line:no-console max-line-length
+            console.error(`[ERROR] ${this.name} received unexpected reply message! payload: ${message.payload.type}, replyToId: ${message.replyToId}`);
         } else {
             delete this.promises[message.replyToId];
             clearTimeout(queuedPromise.timeout);

--- a/packages/sdk/src/types/network/payloads/payloads.ts
+++ b/packages/sdk/src/types/network/payloads/payloads.ts
@@ -356,7 +356,7 @@ export type SetAnimationState = Payload & {
  */
 export type SyncAnimations = Payload & {
     type: 'sync-animations';
-    animationStates: AnimationState[];
+    animationStates: SetAnimationState[];
 };
 
 /**


### PR DESCRIPTION
Fixed an out of date network payload. Non-critical, but was causing the latency calculation to be ignored during animation sync.