### PR TITLE
Return existing asset group if load source is the same

### DIFF
--- a/packages/sdk/src/types/runtime/assets/assetManager.ts
+++ b/packages/sdk/src/types/runtime/assets/assetManager.ts
@@ -111,10 +111,9 @@ export class AssetManager {
         let group: AssetGroup;
         if (this.groups[groupName]) {
             group = this.groups[groupName];
-            if(group.source.containerType === 'gltf' && group.source.uri == uri) {
+            if (group.source.containerType === 'gltf' && group.source.uri === uri) {
                 return group;
-            }
-            else {
+            } else {
                 throw new Error(
                     `Group name ${groupName} is already in use. Unload the old group, or choose a different name.`);
             }

--- a/packages/sdk/src/types/runtime/assets/assetManager.ts
+++ b/packages/sdk/src/types/runtime/assets/assetManager.ts
@@ -108,12 +108,19 @@ export class AssetManager {
     private async loadGltfHelper(
         groupName: string, uri: string, colliderType: CreateColliderType): Promise<AssetGroup> {
 
+        let group: AssetGroup;
         if (this.groups[groupName]) {
-            throw new Error(
-                `Group name ${groupName} is already in use. Unload the old group, or choose a different name.`);
+            group = this.groups[groupName];
+            if(group.source.containerType === 'gltf' && group.source.uri == uri) {
+                return group;
+            }
+            else {
+                throw new Error(
+                    `Group name ${groupName} is already in use. Unload the old group, or choose a different name.`);
+            }
         }
 
-        const group = new AssetGroup(groupName, {
+        group = new AssetGroup(groupName, {
             containerType: 'gltf',
             uri
         });


### PR DESCRIPTION
Fixes functional test errors on successive runs