### PR TITLE
Remove enable-collider payload

### DIFF
--- a/packages/sdk/src/adapters/multipeer/rules.ts
+++ b/packages/sdk/src/adapters/multipeer/rules.ts
@@ -572,32 +572,6 @@ export const Rules: { [id in Payloads.PayloadType]: Rule } = {
     },
 
     // ========================================================================
-    'enable-collider': {
-        ...DefaultRule,
-        synchronization: {
-            stage: 'create-actors',
-            before: 'ignore',
-            during: 'queue',
-            after: 'allow'
-        },
-        session: {
-            ...DefaultRule.session,
-            beforeReceiveFromApp: (
-                session: Session,
-                message: Message<Payloads.EnableCollider>
-            ) => {
-                const syncActor = session.actorSet[message.payload.actorId];
-                if (syncActor) {
-                    // Merge the new component into the existing actor.
-                    syncActor.created.message.payload.actor.collider =
-                        deepmerge(syncActor.created.message.payload.actor.collider || {}, message.payload.collider);
-                }
-                return undefined;
-            }
-        }
-    },
-
-    // ========================================================================
     'engine2app-rpc': {
         ...ClientOnlyRule
     },

--- a/packages/sdk/src/types/internal/context.ts
+++ b/packages/sdk/src/types/internal/context.ts
@@ -46,7 +46,6 @@ import {
     CreateFromPrefab,
     CreatePrimitive,
     DestroyActors,
-    EnableCollider,
     InterpolateActor,
     LookAt,
     ObjectSpawned,

--- a/packages/sdk/src/types/network/payloads/payloads.ts
+++ b/packages/sdk/src/types/network/payloads/payloads.ts
@@ -29,7 +29,6 @@ export type PayloadType
     | 'create-from-prefab'
     | 'create-primitive'
     | 'destroy-actors'
-    | 'enable-collider'
     | 'engine2app-rpc'
     | 'handshake'
     | 'handshake-complete'

--- a/packages/sdk/src/types/network/payloads/physics.ts
+++ b/packages/sdk/src/types/network/payloads/physics.ts
@@ -84,16 +84,6 @@ export type RigidBodyAddRelativeTorque = Payload & {
 
 /**
  * @hidden
- * App to engine. Enable a collider with the given parameters on the actor.
- */
-export type EnableCollider = Payload & {
-    type: 'enable-collider';
-    actorId: string;
-    collider: Partial<ColliderLike>;
-};
-
-/**
- * @hidden
  * App to engine. Update the collision event subscriptions for the given actor.
  */
 export type UpdateCollisionEventSubscriptions = Payload & {


### PR DESCRIPTION
The enable-* payloads have all been removed in favor of using the existing actor patching mechanism whenever possible in order to minimize complexity in the sync layer. @tombuMS you should be able to sync collider state updates the same as other actor components (rigid body, light, text). Let me know if that isn't going to work and we'll figure something out.