### PR TITLE
[SDK] Fixes for stability

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,145 +1,36 @@
 {
-  // See https://go.microsoft.com/fwlink/?LinkId=733558
-  // for the documentation about the tasks.json format
-  "version": "2.0.0",
-  "tasks": [
-    {
-      "type": "npm",
-      "script": "build",
-      "path": "packages/",
-      "presentation": {
-        "echo": true,
-        "reveal": "always",
-        "focus": false,
-        "panel": "shared",
-        "showReuseMessage": true,
-        "clear": true
-      },
-      "problemMatcher": []
-    },
-    {
-      "type": "npm",
-      "script": "build",
-      "path": "packages/sdk/",
-      "presentation": {
-        "echo": true,
-        "reveal": "always",
-        "focus": false,
-        "panel": "shared",
-        "showReuseMessage": true,
-        "clear": true
-      },
-      "problemMatcher": []
-    },
-    {
-      "type": "npm",
-      "script": "build",
-      "path": "packages/functional-tests/",
-      "presentation": {
-        "echo": true,
-        "reveal": "always",
-        "focus": false,
-        "panel": "shared",
-        "showReuseMessage": true,
-        "clear": true
-      },
-      "problemMatcher": []
-    },
-    {
-      "type": "npm",
-      "script": "build",
-      "path": "packages/gltf-gen/",
-      "presentation": {
-        "echo": true,
-        "reveal": "always",
-        "focus": false,
-        "panel": "shared",
-        "showReuseMessage": true,
-        "clear": true
-      },
-      "problemMatcher": []
-    },
-    {
-      "type": "npm",
-      "script": "build",
-      "path": "packages/altspacevr-extras/",
-      "presentation": {
-        "echo": true,
-        "reveal": "always",
-        "focus": false,
-        "panel": "shared",
-        "showReuseMessage": true,
-        "clear": true
-      },
-      "problemMatcher": []
-    },
-    {
-      "type": "npm",
-      "script": "build",
-      "presentation": {
-        "echo": true,
-        "reveal": "always",
-        "focus": false,
-        "panel": "shared",
-        "showReuseMessage": true,
-        "clear": true
-      },
-      "problemMatcher": []
-    },
-    {
-      "type": "npm",
-      "script": "lint",
-      "path": "packages/",
-      "presentation": {
-        "echo": true,
-        "reveal": "always",
-        "focus": false,
-        "panel": "shared",
-        "showReuseMessage": true,
-        "clear": true
-      },
-      "problemMatcher": []
-    },
-    {
-      "type": "npm",
-      "script": "lint",
-      "presentation": {
-        "echo": true,
-        "reveal": "always",
-        "focus": false,
-        "panel": "shared",
-        "showReuseMessage": true,
-        "clear": true
-      },
-      "problemMatcher": []
-    },
-    {
-      "type": "npm",
-      "script": "lint-docs",
-      "path": "packages/",
-      "presentation": {
-        "echo": true,
-        "reveal": "always",
-        "focus": false,
-        "panel": "shared",
-        "showReuseMessage": true,
-        "clear": true
-      },
-      "problemMatcher": []
-    },
-    {
-      "type": "npm",
-      "script": "build-docs",
-      "path": "packages/",
-      "presentation": {
-        "echo": true,
-        "reveal": "always",
-        "focus": false,
-        "panel": "shared",
-        "showReuseMessage": true,
-        "clear": true
-      },
-      "problemMatcher": []
-    }
-  ]
+    // See https://go.microsoft.com/fwlink/?LinkId=733558 
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "type": "npm",
+            "script": "build",
+            "path": "packages/functional-tests/",
+            "problemMatcher": []
+        },
+        {
+            "type": "npm",
+            "script": "build",
+            "path": "packages/sdk/",
+            "problemMatcher": []
+        },
+        {
+            "type": "npm",
+            "script": "build",
+            "problemMatcher": []
+        },
+        {
+            "type": "npm",
+            "script": "build",
+            "path": "packages/altspacevr-extras/",
+            "problemMatcher": []
+        },
+        {
+            "type": "npm",
+            "script": "build",
+            "path": "packages/gltf-gen/",
+            "problemMatcher": []
+        }
+    ]
 }

--- a/packages/sdk/src/adapters/multipeer/adapter.ts
+++ b/packages/sdk/src/adapters/multipeer/adapter.ts
@@ -148,7 +148,7 @@ export class MultipeerAdapter extends Adapter {
             await handshake.run();
 
             // Measure the connection quality and wait for sync-request message.
-            const startup = new ClientStartup(client);
+            const startup = new ClientStartup(client, handshake.syncRequest);
             await startup.run();
 
             // Get the session for the sessionId.

--- a/packages/sdk/src/adapters/multipeer/client.ts
+++ b/packages/sdk/src/adapters/multipeer/client.ts
@@ -130,8 +130,9 @@ export class Client extends EventEmitter {
         const beforeQueueMessageForClient = rule.client.beforeQueueMessageForClient || (() => message);
         message = beforeQueueMessageForClient(this.session, this, message, promise);
         if (message) {
-            log.verbose('network', `Client ${this.id} queue`,
-                JSON.stringify(message, (key, value) => filterEmpty(value)));
+            // tslint:disable-next-line:max-line-length
+            log.verbose('network', `Client ${this.id.substr(0, 8)} queue id:${message.id.substr(0, 8)}, type:${message.payload.type}`);
+            log.verbose('network-content', JSON.stringify(message, (key, value) => filterEmpty(value)));
             this.queuedMessages.push({ message, promise });
         }
     }

--- a/packages/sdk/src/adapters/multipeer/protocols/clientExecution.ts
+++ b/packages/sdk/src/adapters/multipeer/protocols/clientExecution.ts
@@ -16,10 +16,14 @@ export class ClientExecution extends Protocols.Protocol implements Protocols.Mid
     private heartbeatTimer: NodeJS.Timer;
 
     /** @override */
-    public get name(): string { return `${this.constructor.name} client ${this.client.id}`; }
+    public get name(): string { return `${this.constructor.name} client ${this.client.id.substr(0, 8)}`; }
 
     constructor(private client: Client) {
         super(client.conn);
+        // Set timeout a little shorter than the app/session connection, ensuring we don't
+        // cause an app/session message timeout - which is not a supported scenario (there
+        // is no reconnect).
+        this.timeoutSeconds = Protocols.DefaultConnectionTimeoutSeconds * 2 / 3;
         this.heartbeat = new Protocols.Heartbeat(this);
         this.beforeRecv = this.beforeRecv.bind(this);
         // Behave like a server-side endpoint (send heartbeats, measure connection quality)

--- a/packages/sdk/src/adapters/multipeer/protocols/clientHandshake.ts
+++ b/packages/sdk/src/adapters/multipeer/protocols/clientHandshake.ts
@@ -12,9 +12,7 @@ import { OperatingModel } from '../../../types/network/operatingModel';
  */
 export class ClientHandshake extends Handshake {
     /** @override */
-    public get name(): string {
-        return `${this.constructor.name} client ${this.client.id}`;
-    }
+    public get name(): string { return `${this.constructor.name} client ${this.client.id.substr(0, 8)}`; }
 
     constructor(private client: Client, sessionId: string) {
         super(client.conn, sessionId, OperatingModel.PeerAuthoritative);

--- a/packages/sdk/src/adapters/multipeer/protocols/clientStartup.ts
+++ b/packages/sdk/src/adapters/multipeer/protocols/clientStartup.ts
@@ -9,18 +9,28 @@ import * as Payloads from '../../../types/network/payloads';
 
 export class ClientStartup extends Protocols.Protocol {
     /** @override */
-    public get name(): string { return `${this.constructor.name} client ${this.client.id}`; }
+    public get name(): string { return `${this.constructor.name} client ${this.client.id.substr(0, 8)}`; }
 
-    constructor(private client: Client) {
+    constructor(private client: Client, syncRequest: Payloads.SyncRequest) {
         super(client.conn);
         // Behave like a server-side endpoint (send heartbeats, measure connection quality).
         this.use(new Protocols.ServerPreprocessing());
+        // If we've already received the 'sync-request' payload, process it now.
+        if (syncRequest) {
+            setImmediate(async () => {
+                await this.performStartup(syncRequest);
+            });
+        }
     }
 
     /**
      * @hidden
      */
     public 'recv-sync-request' = async (payload: Payloads.SyncRequest) => {
+        await this.performStartup(payload);
+    }
+
+    private async performStartup(payload: Payloads.SyncRequest) {
         // Do a quick measurement of connection latency.
         const heartbeat = new Protocols.Heartbeat(this);
         await heartbeat.runIterations(10); // Allow exceptions to propagate out.

--- a/packages/sdk/src/adapters/multipeer/rules.ts
+++ b/packages/sdk/src/adapters/multipeer/rules.ts
@@ -303,7 +303,7 @@ export const Rules: { [id in Payloads.PayloadType]: Rule } = {
                         // (if keys.length === 1, it only contains the actor.id field)
                         if (Object.keys(payloadForClients.actor).length > 1) {
                             // Sync the change to the other clients.
-                            session.sendPayloadToClients(payloadForClients, client.id);
+                            session.sendPayloadToClients(payloadForClients, (value) => value.id !== client.id);
                         }
 
                         // Determine whether to forward the message to the app based on subscriptions.
@@ -855,7 +855,7 @@ export const Rules: { [id in Payloads.PayloadType]: Rule } = {
                             if (createdAnimation) {
                                 createdAnimation.enabled = message.payload.state.enabled;
                                 // Propagate to other clients.
-                                session.sendToClients(message, client.id);
+                                session.sendToClients(message, (value) => value.id !== client.id);
                             }
                             // Remove the completed interpolation.
                             syncActor.activeInterpolations =

--- a/packages/sdk/src/protocols/handshake.ts
+++ b/packages/sdk/src/protocols/handshake.ts
@@ -14,6 +14,8 @@ import { Protocol } from './protocol';
  * Class to manage the handshake process with a client.
  */
 export class Handshake extends Protocol {
+    public syncRequest: Payloads.SyncRequest;
+
     constructor(conn: Connection, private sessionId: string, private operatingModel: OperatingModel) {
         super(conn);
         // Behave like a server-side endpoint (send heartbeats, measure connection quality)
@@ -32,5 +34,12 @@ export class Handshake extends Protocol {
     /** @private */
     public 'recv-handshake-complete' = (payload: Payloads.HandshakeComplete) => {
         this.resolve();
+    }
+
+    /** @private */
+    public 'recv-sync-request' = (payload: Payloads.SyncRequest) => {
+        // The way the protocol works right now, this message can be sent unexpectedly early by the client.
+        // If we receive it, we'll cache it and pass it along to the next protocol.
+        this.syncRequest = payload;
     }
 }

--- a/packages/sdk/src/types/network/message.ts
+++ b/packages/sdk/src/types/network/message.ts
@@ -34,4 +34,9 @@ export type Message<PayloadT = Payload> = {
      * The message payload.
      */
     payload: Partial<PayloadT>;
+
+    /**
+     * Workaround for a piece of state missing in the multipeer adapter. Not sent to client.
+     */
+    awaitingResponse?: boolean;
 };


### PR DESCRIPTION
Found and fixed numerous issues exposed by stressing network traffic in different ways.
- Fix for #188: "Multi-peer bug: Queued actions can be sent before actor is ready." When the app sends a message that expects a reply, the multipeer adapter will now wait for replies from all peers before forwarding the reply back to the app.
- There was a small window of time between client 'handshake' and 'startup' steps where a message could get dropped. It's a weakness in the protocol design. Added a workaround for now. Will revisit the design later.
- During animation synchronization there's an edge case that could result in an unexpected reply message. Added a workaround for that. This issue will go away soon with the planned anim sync refactor.
- All messages that expect a reply must be able to handle a response type of `operation-result`. Updated this everywhere.
- `createAnimation` was expecting the wrong response message type.
- `setAnimationState` now waits until the actor is created. 

Also:
- Changed network logging so that logging to the 'network' facility shows a summary of network traffic. To see the contents of network traffic, use `log.enable('network-content');`
