### PR TITLE
[SDK] More networking fixes

### DIFF
--- a/packages/sdk/src/adapters/multipeer/client.ts
+++ b/packages/sdk/src/adapters/multipeer/client.ts
@@ -101,16 +101,8 @@ export class Client extends EventEmitter {
         } catch { }
     }
 
-    public joinedOrLeft() {
-        if (this.protocol && this.protocol.constructor.name === "ClientExecution") {
-            return Promise.resolve();
-        }
-        return new Promise((resolve, reject) => {
-            const test = () =>
-                (!this.protocol || this.protocol.constructor.name === "ClientExecution") ? resolve() : set();
-            const set = () => setTimeout(test, 25);
-            set();
-        });
+    public isJoined() {
+        return this.protocol && this.protocol.constructor.name === "ClientExecution";
     }
 
     public send(message: Message, promise?: ExportedPromise) {

--- a/packages/sdk/src/adapters/multipeer/client.ts
+++ b/packages/sdk/src/adapters/multipeer/client.ts
@@ -34,6 +34,7 @@ export class Client extends EventEmitter {
     private _protocol: Protocols.Protocol;
     private _order: number;
     private _queuedMessages: QueuedMessage[] = [];
+    private _authoritative = false;
     // tslint:enable:variable-name
 
     public get id() { return this._id; }
@@ -41,10 +42,7 @@ export class Client extends EventEmitter {
     public get protocol() { return this._protocol; }
     public get session() { return this._session; }
     public get conn() { return this._conn; }
-    public get authoritative() {
-        return (0 === this.session.clients.sort((a, b) => a.order - b.order)
-            .findIndex(client => client.id === this.id));
-    }
+    public get authoritative() { return this._authoritative; }
     public get queuedMessages() { return this._queuedMessages; }
 
     public userId: string;
@@ -60,6 +58,14 @@ export class Client extends EventEmitter {
         this.leave = this.leave.bind(this);
         this._conn.on('close', this.leave);
         this._conn.on('error', this.leave);
+    }
+
+    public setAuthoritative(value: boolean) {
+        this._authoritative = value;
+        this.protocol.sendPayload({
+            type: 'set-authoritative',
+            authoritative: value
+        } as Payloads.SetAuthoritative);
     }
 
     /**

--- a/packages/sdk/src/adapters/multipeer/protocols/clientSync.ts
+++ b/packages/sdk/src/adapters/multipeer/protocols/clientSync.ts
@@ -193,14 +193,13 @@ export class ClientSync extends Protocols.Protocol {
      * Driver for the `sync-animations` synchronization stage.
      */
     public 'stage:sync-animations' = async () => {
-        // Don't send the sync-animations message to ourselves.
-        if (this.client.session.authoritativeClient.order === this.client.order) {
+        const authoritativeClient = this.client.session.authoritativeClient;
+        if (!authoritativeClient) {
             return Promise.resolve();
         }
         return new Promise<void>((resolve, reject) => {
             // Request the current state of all animations from the authoritative client.
             // TODO: Improve this (don't rely on a peer).
-            const authoritativeClient = this.client.session.authoritativeClient;
             authoritativeClient.sendPayload({
                 type: 'sync-animations',
             } as Payloads.SyncAnimations, {
@@ -215,10 +214,7 @@ export class ClientSync extends Protocols.Protocol {
                         }
                         // Pass with an empty reply handler to account for an edge case that will go away once
                         // animation synchronization is refactored.
-                        super.sendPayload(payload, {
-                            resolve: () => { },
-                            reject: () => { }
-                        });
+                        super.sendPayload(payload);
                         resolve();
                     }, reject
                 });

--- a/packages/sdk/src/adapters/multipeer/rules.ts
+++ b/packages/sdk/src/adapters/multipeer/rules.ts
@@ -899,6 +899,8 @@ export const Rules: { [id in Payloads.PayloadType]: Rule } = {
                 const syncActor = session.actorSet[message.payload.actorId];
                 if (syncActor) {
                     syncActor.behavior = message.payload.behaviorType;
+                } else {
+                    console.log(`[ERROR] Sync: set-behavior on unknown actor ${message.payload.actorId}`);
                 }
                 return message;
             }

--- a/packages/sdk/src/protocols/protocol.ts
+++ b/packages/sdk/src/protocols/protocol.ts
@@ -105,7 +105,9 @@ export class Protocol extends EventEmitter {
             if (this.timeoutSeconds > 0) {
                 return setTimeout(() => {
                     // tslint:disable-next-line:max-line-length
-                    this.rejectPromiseForMessage(message.id, `Timed out awaiting response for ${message.payload.type}, id:${message.id}.`);
+                    const reason = `Timed out awaiting response for ${message.payload.type}, id:${message.id}.`;
+                    log.error('network', reason);
+                    this.rejectPromiseForMessage(message.id, reason);
                     this.conn.close();
                 }, this.timeoutSeconds * 1000);
             }


### PR DESCRIPTION
This PR contains three bugfixes:
1. A race condition in the client join process vs. how we were tracking the authoritative peer could cause a mismatch between which peer the server considered authoritative and which client was acting as the authoritative peer. Bug symptoms include: Behaviors not responding on non-authoritative instances. We've seen this a lot in the wild, where something isn't clickable. Really great to have tracked this one down.
2. A regression introduced in my last PR would cause every non-authoritative peer to repeatedly disconnect after a minute then reconnect. Doh!
3. A regression introduced in my last PR where client replies weren't getting preprocessed, resulting in gaps in the cached synchronization state. Doh!

To whoever added the Connect and Disconnect buttons to the MREComponent in the MRETestBed, THANK YOU! Super helpful.