### PR TITLE
[SDK] Standardize on lower-case, dash-formatted enum values.

### DIFF
--- a/packages/sdk/src/types/primitiveTypes.ts
+++ b/packages/sdk/src/types/primitiveTypes.ts
@@ -49,14 +49,14 @@ export enum PrimitiveShape {
      * [[PrimitiveDefinition.uSegments]], and vertical segment count [[PrimitiveDefinition.vSegments]], with normals
      * pointed inward, centered at the origin.
      */
-    InnerSphere = 'innersphere'
+    InnerSphere = 'inner-sphere'
 }
 
 /**
  * The size, shape, and description of a primitive.
  */
 export interface PrimitiveDefinition {
-
+    // TODO: Make this a discriminated union type.
     /**
      * The general shape of the defined primitive.
      */

--- a/packages/sdk/src/types/rigidBodyConstraints.ts
+++ b/packages/sdk/src/types/rigidBodyConstraints.ts
@@ -7,14 +7,14 @@
  * Flags to constrain rigid body motion.
  */
 export enum RigidBodyConstraints {
-    None = 'None',
-    FreezePositionX = 'FreezePositionX',
-    FreezePositionY = 'FreezePositionY',
-    FreezePositionZ = 'FreezePositionZ',
-    FreezePosition = 'FreezePosition',
-    FreezeRotationX = 'FreezeRotationX',
-    FreezeRotationY = 'FreezeRotationY',
-    FreezeRotationZ = 'FreezeRotationZ',
-    FreezeRotation = 'FreezeRotation',
-    FreezeAll = 'FreezeAll',
+    None = 'none',
+    FreezePositionX = 'freeze-position-x',
+    FreezePositionY = 'freeze-position-y',
+    FreezePositionZ = 'freeze-position-z',
+    FreezePosition = 'freeze-position',
+    FreezeRotationX = 'freeze-rotation-x',
+    FreezeRotationY = 'freeze-rotation-y',
+    FreezeRotationZ = 'freeze-rotation-z',
+    FreezeRotation = 'freeze-rotation',
+    FreezeAll = 'freeze-all',
 }

--- a/packages/sdk/src/types/runtime/assets/material.ts
+++ b/packages/sdk/src/types/runtime/assets/material.ts
@@ -34,16 +34,16 @@ export interface MaterialLike {
  */
 export enum AlphaMode {
     /** The object is rendered opaque, and transparency info is discarded. */
-    Opaque = 'Opaque',
+    Opaque = 'opaque',
     /**
      * Any parts with alpha above a certain cutoff ([[Material.alphaCutoff]])
      * will be rendered solid. Everything else is fully transparent.
      */
-    Mask = 'Mask',
+    Mask = 'mask',
     /**
      * A pixel's transparency is directly proportional to its alpha value.
      */
-    Blend = 'Blend'
+    Blend = 'blend'
 }
 
 /**

--- a/packages/sdk/src/types/runtime/text.ts
+++ b/packages/sdk/src/types/runtime/text.ts
@@ -6,26 +6,26 @@
 import { Color3, Color3Like } from '../..';
 
 export enum TextAnchorLocation {
-    TopLeft = 'TopLeft',
-    TopCenter = 'TopCenter',
-    TopRight = 'TopRight',
-    MiddleLeft = 'MiddleLeft',
-    MiddleCenter = 'MiddleCenter',
-    MiddleRight = 'MiddleRight',
-    BottomLeft = 'BottomLeft',
-    BottomCenter = 'BottomCenter',
-    BottomRight = 'BottomRight',
+    TopLeft = 'top-left',
+    TopCenter = 'top-center',
+    TopRight = 'top-right',
+    MiddleLeft = 'middle-left',
+    MiddleCenter = 'middle-center',
+    MiddleRight = 'middle-right',
+    BottomLeft = 'bottom-left',
+    BottomCenter = 'bottom-center',
+    BottomRight = 'bottom-right',
 }
 
 export enum TextJustify {
-    Left = 'Left',
-    Center = 'Center',
-    Right = 'Right',
+    Left = 'left',
+    Center = 'center',
+    Right = 'right',
 }
 
 export enum TextFontFamily {
-    Serif = 'Serif',
-    SansSerif = 'SansSerif',
+    Serif = 'serif',
+    SansSerif = 'sans-serif',
 }
 
 export interface TextLike {


### PR DESCRIPTION
This is a cleanup pass on our enum values to use a dash-formatted, lower-case format. For the sake of back-compatibility, I won't merge this PR until https://github.com/Microsoft/mixed-reality-extension-unity/pull/33 has been integrated into AltspaceVR and released.