### PR TITLE
Multiple fixes for issues uncovered while running functional tests

### DIFF
--- a/packages/functional-tests/src/tests/interpolation-test.ts
+++ b/packages/functional-tests/src/tests/interpolation-test.ts
@@ -6,6 +6,7 @@
 import * as MRE from '@microsoft/mixed-reality-extension-sdk';
 
 import { Test } from '../test';
+import delay from '../utils/delay';
 
 export default class InterpolationTest extends Test {
     public expectedResultDescription = "Lerping scale and rotation";
@@ -35,9 +36,10 @@ export default class InterpolationTest extends Test {
             const easeIndex = Math.floor(Math.random() * easeCurveKeys.length);
             const easeCurveKey = easeCurveKeys[easeIndex];
             // Interpolate object's rotation and scale.
-            await cube.animateTo(
+            cube.animateTo(
                 { transform: { rotation, scale } },
                 1.0, (MRE.AnimationEaseCurves as any)[easeCurveKey]);
+            await delay(1000);
         }
 
         return true;

--- a/packages/functional-tests/src/tests/light-test.ts
+++ b/packages/functional-tests/src/tests/light-test.ts
@@ -6,6 +6,7 @@
 import * as MRE from '@microsoft/mixed-reality-extension-sdk';
 
 import { Test } from '../test';
+import delay from '../utils/delay';
 
 // tslint:disable:no-string-literal
 
@@ -40,12 +41,13 @@ export default class LightTest extends Test {
                     props['monkey'].transform.position,
                     new MRE.Vector3(0, -Math.PI / 8, 0));
                 sphere.light.color = randomColor();
-                await sphere.animateTo({
+                sphere.animateTo({
                     transform: {
                         position,
                         rotation
                     }
                 }, time, MRE.AnimationEaseCurves.EaseInOutSine);
+                await delay(time * 1000);
             }
         };
 

--- a/packages/sdk/src/adapters/multipeer/protocols/clientSync.ts
+++ b/packages/sdk/src/adapters/multipeer/protocols/clientSync.ts
@@ -278,11 +278,7 @@ export class ClientSync extends Protocols.Protocol {
         return new Promise<void>((resolve, reject) => {
             super.sendMessage(message, {
                 resolve: (replyPayload: any, replyMessage: Message) => {
-                    if (this.client.authoritative) {
-                        // If this client is authoritative while synchonizing, then it is the only client joined.
-                        // In this case we want to send the reply message back to the app since it is expecting it.
-                        this.client.session.conn.send(replyMessage);
-                    }
+                    this.client.session.conn.send(replyMessage);
                     resolve(replyPayload);
                 }, reject
             });

--- a/packages/sdk/src/adapters/multipeer/protocols/clientSync.ts
+++ b/packages/sdk/src/adapters/multipeer/protocols/clientSync.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import UUID from 'uuid/v4';
 import { Client, MissingRule, Rules, SyncActor } from '..';
 import { Message } from '../../..';
 import { log } from '../../../log';
@@ -55,6 +56,7 @@ export class ClientSync extends Protocols.Protocol {
      * Handle the outgoing message according to the synchronization rules specified for this payload.
      */
     public sendMessage(message: Message, promise?: ExportedPromise) {
+        message.id = message.id || UUID();
         const handling = this.handlingForMessage(message);
         // tslint:disable-next-line:switch-default
         switch (handling) {

--- a/packages/sdk/src/adapters/multipeer/session.ts
+++ b/packages/sdk/src/adapters/multipeer/session.ts
@@ -215,6 +215,8 @@ export class Session extends EventEmitter {
                 for (const client of clients) {
                     client.send({ ...message }, {
                         resolve: (payload: Payloads.Payload, response: Message) => {
+                            // tslint:disable-next-line:max-line-length
+                            log.verbose('network-content', `"Received resolve response for id:${message.id.substr(0, 8)} from client:${client.id.substr(0, 8)}`);
                             // Decrement the wait counter.
                             awaitCount -= 1;
                             // Preprocess the response message.
@@ -238,6 +240,8 @@ export class Session extends EventEmitter {
                             }
                         },
                         reject: () => {
+                            // tslint:disable-next-line:max-line-length
+                            log.verbose('network-content', `"Received reject response for id:${message.id.substr(0, 8)} from client:${client.id.substr(0, 8)}`);
                             // Something bad happened on this connection and we didn't get a response. That's fine.
                             // Decrement the wait counter.
                             awaitCount -= 1;

--- a/packages/sdk/src/types/internal/context.ts
+++ b/packages/sdk/src/types/internal/context.ts
@@ -303,8 +303,7 @@ export class InternalContext {
                         state
                     } as SetAnimationState))
                     .catch((reason) => log.error('app', reason));
-            })
-            .catch((reason) => log.error('app', reason));
+            }).catch((reason) => log.error('app', reason));
         } else {
             log.error('app', `Failed to set animation state on ${animationName}. Actor ${actorId} not found.`);
         }
@@ -318,26 +317,22 @@ export class InternalContext {
     ) {
         const actor = this.actorSet[actorId];
         if (!actor) {
-            return Promise.reject(`Failed animateTo. Actor ${actorId} not found`);
+            log.error('app', `Failed animateTo. Actor ${actorId} not found.`);
         } else if (!Array.isArray(curve) || curve.length !== 4) {
-            return Promise.reject('`curve` parameter must be an array of four numbers. \
-            Try passing one of the predefined curves from `AnimationEaseCurves`');
+            // tslint:disable-next-line:max-line-length
+            log.error('app', '`curve` parameter must be an array of four numbers. Try passing one of the predefined curves from `AnimationEaseCurves`');
         } else {
-            return new Promise<void>((resolve, reject) => {
-                actor.created().then(() => {
-                    this.protocol.sendPayload({
-                        type: 'interpolate-actor',
-                        actorId,
-                        animationName: UUID(),
-                        value,
-                        duration,
-                        curve,
-                        enabled: true
-                    } as InterpolateActor, { resolve, reject });
-                }).catch((reason: any) => {
-                    log.error('app', `Failed animateTo. Actor ${actor.id}. ${(reason || '').toString()}`.trim());
-                });
-            });
+            actor.created().then(() => {
+                this.protocol.sendPayload({
+                    type: 'interpolate-actor',
+                    actorId,
+                    animationName: UUID(),
+                    value,
+                    duration,
+                    curve,
+                    enabled: true
+                } as InterpolateActor);
+            }).catch((reason) => log.error('app', reason));
         }
     }
 

--- a/packages/sdk/src/types/runtime/actor.ts
+++ b/packages/sdk/src/types/runtime/actor.ts
@@ -575,10 +575,9 @@ export class Actor implements ActorLike, Patchable<ActorLike> {
      * @param value The desired final state of the animation.
      * @param duration The length of the interpolation (in seconds).
      * @param curve The cubic-bezier curve parameters. @see AnimationEaseCurves for predefined values.
-     * @returns Returns a Promise that is resolves after the animation completes.
      */
-    public animateTo(value: Partial<ActorLike>, duration: number, curve: number[]): Promise<void> {
-        return this.context.internal.animateTo(this.id, value, duration, curve);
+    public animateTo(value: Partial<ActorLike>, duration: number, curve: number[]) {
+        this.context.internal.animateTo(this.id, value, duration, curve);
     }
 
     /**

--- a/packages/sdk/src/utils/readPath.ts
+++ b/packages/sdk/src/utils/readPath.ts
@@ -21,7 +21,7 @@ export default function readPath(src: any, dst: any, ...path: string[]) {
             dst = dst[field];
         }
         if (typeof src[field] === 'undefined') {
-            throw new Error("readPath: Data structure mismatch.");
+            return;
         }
         src = src[field];
     }


### PR DESCRIPTION
**Fixes**
- AnimateTo should not have a reply message. This was causing the app to hang when one user left.
- readPath (in patching system) should not die on undefined values. Now it just ignores them.
- During client sync, we don't have a reliable way to know whether to send reply messages back to the app, so now we just send them all back and let the app's protocol layer sort it out.

**Unresolved issues**
- When a client disconnects, we don't clean up outstanding promises for messages awaiting replies. This will cause a timeout and kill the session.
- When the session is killed this way, it doesn't clean up properly.
- I will follow up on these Monday.

