### PR TITLE
set-sound-state shouldn't expect a response during sync

### DIFF
--- a/packages/sdk/src/adapters/multipeer/protocols/clientSync.ts
+++ b/packages/sdk/src/adapters/multipeer/protocols/clientSync.ts
@@ -285,7 +285,7 @@ export class ClientSync extends Protocols.Protocol {
                         }
                         activeSoundInstance.message.payload.startTimeOffset += timeOffset;
                     }
-                    return this.sendAndExpectResponse(activeSoundInstance.message);
+                    return this.sendMessage(activeSoundInstance.message);
                 })
         ]);
     }


### PR DESCRIPTION
After playing a sound, new users weren't able to fully sync up to the app. This was the culprit.