### PR TITLE
[SDK] Move message queuing to the client

### DIFF
--- a/packages/functional-tests/src/tests/asset-mutability-test.ts
+++ b/packages/functional-tests/src/tests/asset-mutability-test.ts
@@ -20,7 +20,7 @@ export default class AssetMutabilityTest extends Test {
         );
 
         const mat = assets.materials.byIndex(0);
-        const box = await MRE.Actor.CreatePrimitive(this.app.context, {
+        MRE.Actor.CreatePrimitive(this.app.context, {
             definition: {
                 shape: MRE.PrimitiveShape.Box,
                 dimensions: { x: 1, y: 1, z: 1 }

--- a/packages/functional-tests/src/tests/clock-sync-test.ts
+++ b/packages/functional-tests/src/tests/clock-sync-test.ts
@@ -71,19 +71,14 @@ export default class ClockSyncTest extends Test {
 
         // Build animations.
         const yOffset = boxYPosition + lineHeight * 0.5;
-        const animations = [
-            this.buildDigitAnimation(meshHundredths.value, 4.25, yOffset, 1 / 100, 10, 10, lineHeight, textScale),
-            this.buildDigitAnimation(meshTenths.value, 3.25, yOffset, 1 / 10, 10, 10, lineHeight, textScale),
-            this.buildDigitAnimation(meshSeconds.value, 1.75, yOffset, 1, 10, 10, lineHeight, textScale),
-            this.buildDigitAnimation(mesh10Seconds.value, 0.75, yOffset, 10, 6, 6, lineHeight, textScale),
-            this.buildDigitAnimation(meshMinutes.value, -0.75, yOffset, 60, 10, 10, lineHeight, textScale),
-            this.buildDigitAnimation(mesh10Minutes.value, -1.75, yOffset, 10 * 60, 6, 6, lineHeight, textScale),
-            this.buildDigitAnimation(meshHours.value, -3.25, yOffset, 60 * 60, 24, 24, lineHeight, textScale),
-            this.buildDigitAnimation(mesh10Hours.value, -4.25, yOffset, 10 * 60 * 60, 3, 2.4, lineHeight, textScale)
-        ];
-
-        // Wait for all actors and animations to instantiate on the host.
-        await Promise.all([actors, animations]);
+        this.buildDigitAnimation(meshHundredths.value, 4.25, yOffset, 1 / 100, 10, 10, lineHeight, textScale);
+        this.buildDigitAnimation(meshTenths.value, 3.25, yOffset, 1 / 10, 10, 10, lineHeight, textScale);
+        this.buildDigitAnimation(meshSeconds.value, 1.75, yOffset, 1, 10, 10, lineHeight, textScale);
+        this.buildDigitAnimation(mesh10Seconds.value, 0.75, yOffset, 10, 6, 6, lineHeight, textScale);
+        this.buildDigitAnimation(meshMinutes.value, -0.75, yOffset, 60, 10, 10, lineHeight, textScale);
+        this.buildDigitAnimation(mesh10Minutes.value, -1.75, yOffset, 10 * 60, 6, 6, lineHeight, textScale);
+        this.buildDigitAnimation(meshHours.value, -3.25, yOffset, 60 * 60, 24, 24, lineHeight, textScale);
+        this.buildDigitAnimation(mesh10Hours.value, -4.25, yOffset, 10 * 60 * 60, 3, 2.4, lineHeight, textScale);
 
         // Start the animations.
         actors.forEach(actor => actor.value.enableAnimation('anim'));
@@ -117,7 +112,7 @@ export default class ClockSyncTest extends Test {
         digits: number,
         frameCount: number,
         lineHeight: number,
-        scale: number): Promise<void> {
+        scale: number) {
 
         const keyframes: MRE.AnimationKeyframe[] = [];
 
@@ -162,7 +157,7 @@ export default class ClockSyncTest extends Test {
             }
         }
 
-        return mesh.createAnimation(
+        mesh.createAnimation(
             'anim', {
                 wrapMode: MRE.AnimationWrapMode.Loop,
                 keyframes

--- a/packages/functional-tests/src/tests/gltf-animation-test.ts
+++ b/packages/functional-tests/src/tests/gltf-animation-test.ts
@@ -11,7 +11,7 @@ export default class GltfAnimationTest extends Test {
     public expectedResultDescription = "Cesium Man walking";
 
     public async run(): Promise<boolean> {
-        const tester = await MRE.Actor.CreateFromGltf(this.app.context, {
+        const tester = MRE.Actor.CreateFromGltf(this.app.context, {
             // tslint:disable-next-line:max-line-length
             resourceUrl: `https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/CesiumMan/glTF-Binary/CesiumMan.glb`,
             actor: {
@@ -19,7 +19,7 @@ export default class GltfAnimationTest extends Test {
                     position: { y: -0.72 }
                 }
             }
-        });
+        }).value;
         tester.enableAnimation('animation:0');
         this.app.rpc.send('functional-test:trace-message', 'gltf-animation-test', "start animation");
 

--- a/packages/functional-tests/src/tests/gltf-concurrency-test.ts
+++ b/packages/functional-tests/src/tests/gltf-concurrency-test.ts
@@ -16,6 +16,7 @@ export default class GltfConcurrencyTest extends Test {
             resourceUrl: `https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/CesiumMan/glTF-Binary/CesiumMan.glb`,
             actor: { transform: { position: { x: 0.66, y: -0.72 } } }
         });
+        const runner = runnerPromise.value;
 
         const gearboxPromise = MRE.Actor.CreateFromGltf(this.app.context, {
             // tslint:disable-next-line:max-line-length
@@ -27,22 +28,23 @@ export default class GltfConcurrencyTest extends Test {
             // tslint:disable-next-line:max-line-length
             'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/WaterBottle/glTF/WaterBottle.gltf');
 
+        runner.enableAnimation('animation:0');
+
         try {
             await gearboxPromise;
         } catch (e) {
             console.log('Gearbox didn\'t load, as expected in Altspace');
         }
 
-        let runner: MRE.Actor;
+        let runnerActor: MRE.Actor;
         let bottleAsset: MRE.AssetGroup;
         try {
-            [runner, bottleAsset] = await Promise.all([runnerPromise, bottlePromise]);
+            [runnerActor, bottleAsset] = await Promise.all([runnerPromise, bottlePromise]);
         } catch (errs) {
             console.error(errs);
             return false;
         }
 
-        runner.enableAnimation('animation:0');
         await MRE.Actor.CreateFromPrefab(this.app.context, {
             prefabId: bottleAsset.prefabs.byIndex(0).id,
             actor: { transform: { position: { x: -.66 }, scale: { x: 4, y: 4, z: 4 } } }

--- a/packages/functional-tests/src/tests/gltf-concurrency-test.ts
+++ b/packages/functional-tests/src/tests/gltf-concurrency-test.ts
@@ -45,7 +45,7 @@ export default class GltfConcurrencyTest extends Test {
             return false;
         }
 
-        await MRE.Actor.CreateFromPrefab(this.app.context, {
+        MRE.Actor.CreateFromPrefab(this.app.context, {
             prefabId: bottleAsset.prefabs.byIndex(0).id,
             actor: { transform: { position: { x: -.66 }, scale: { x: 4, y: 4, z: 4 } } }
         });

--- a/packages/functional-tests/src/tests/gltf-gen-test.ts
+++ b/packages/functional-tests/src/tests/gltf-gen-test.ts
@@ -32,7 +32,7 @@ export default class GltfGenTest extends Test {
             })]
         })]);
 
-        await MRE.Actor.CreateFromGltf(this.app.context, {
+        MRE.Actor.CreateFromGltf(this.app.context, {
             resourceUrl: Server.registerStaticBuffer('sphere.glb', gltfFactory.generateGLTF())
         });
 

--- a/packages/functional-tests/src/tests/input-test.ts
+++ b/packages/functional-tests/src/tests/input-test.ts
@@ -35,22 +35,22 @@ export default class InputTest extends Test {
         this.model.createAnimation(
             'GrowIn', {
                 keyframes: this.growAnimationData
-            }).catch(reason => console.log(`Failed to create grow animation: ${reason}`));
+            });
 
         this.model.createAnimation(
             'ShrinkOut', {
                 keyframes: this.shrinkAnimationData
-            }).catch(reason => console.log(`Failed to create shrink animation: ${reason}`));
+            });
 
         this.model.createAnimation(
             'Spin1', {
                 keyframes: this.generateSpinKeyframes(0.5, MRE.Vector3.Up()),
-            }).catch(reason => console.log(`Failed to create flip animation: ${reason}`));
+            });
 
         this.model.createAnimation(
             'Spin2', {
                 keyframes: this.generateSpinKeyframes(0.5, MRE.Vector3.Up(), Math.PI),
-            }).catch(reason => console.log(`Failed to create flip animation: ${reason}`));
+            });
 
         // Set up cursor interaction. We add the input behavior ButtonBehavior to the cube.
         // Button behaviors have two pairs of events: hover start/stop, and click start/stop.

--- a/packages/functional-tests/src/tests/look-at-test.ts
+++ b/packages/functional-tests/src/tests/look-at-test.ts
@@ -36,7 +36,7 @@ export default class LookAtTest extends Test {
         tester.createAnimation('circle', {
             wrapMode: MRE.AnimationWrapMode.Loop,
             keyframes: circleKeyframes
-        }).catch(() => { });
+        });
         tester.enableAnimation('circle');
 
         this.interval = setInterval(() => {

--- a/packages/functional-tests/src/tests/sound-test.ts
+++ b/packages/functional-tests/src/tests/sound-test.ts
@@ -164,8 +164,7 @@ export default class SoundTest extends Test {
             'flyaround', {
                 keyframes: this.generateSpinKeyframes(2.0, MRE.Vector3.Up()),
                 wrapMode: MRE.AnimationWrapMode.Loop
-
-            }).catch(reason => console.log(`Failed to create flip animation: ${reason}`));
+            });
 
         const dopplerAssetPromise = this.app.context.assetManager.createSound(
             'group1',

--- a/packages/sdk/src/adapters/multipeer/protocols/clientSync.ts
+++ b/packages/sdk/src/adapters/multipeer/protocols/clientSync.ts
@@ -279,10 +279,8 @@ export class ClientSync extends Protocols.Protocol {
     }
 
     private createActorAnimations(actor: Partial<SyncActor>) {
-        return Promise.all([
-            (actor.createdAnimations || [])
-                .map(createdAnimation => this.sendMessage(createdAnimation.message))
-        ]);
+        (actor.createdAnimations || [])
+            .map(createdAnimation => this.sendMessage(createdAnimation.message));
     }
 
     private createActorInterpolations(actor: Partial<SyncActor>) {

--- a/packages/sdk/src/protocols/protocol.ts
+++ b/packages/sdk/src/protocols/protocol.ts
@@ -124,13 +124,6 @@ export class Protocol extends EventEmitter {
         log.verbose('network', `${this.name} send id:${message.id.substr(0, 8)}, type:${message.payload.type}`);
         log.verbose('network-content', JSON.stringify(message, (key, value) => filterEmpty(value)));
 
-        // Let the multipeer adapter know the SDK is awaiting a response to this message, so that it can in turn
-        // wait for all peer responses before forwarding the client's response back to the app. This is needed so
-        // that the app knows the operation completed on all peers before proceeding.
-        if (promise) {
-            message.awaitingResponse = true;
-        }
-
         this.conn.send(message);
     }
 

--- a/packages/sdk/src/types/network/message.ts
+++ b/packages/sdk/src/types/network/message.ts
@@ -34,9 +34,4 @@ export type Message<PayloadT = Payload> = {
      * The message payload.
      */
     payload: Partial<PayloadT>;
-
-    /**
-     * Workaround for a piece of state missing in the multipeer adapter. Not sent to client.
-     */
-    awaitingResponse?: boolean;
 };

--- a/packages/sdk/src/types/runtime/actor.ts
+++ b/packages/sdk/src/types/runtime/actor.ts
@@ -265,17 +265,6 @@ export class Actor implements ActorLike, Patchable<ActorLike> {
     }
 
     /**
-     * Provides an awaitable object that resolves once the actor has been created on the host.
-     */
-    public created() {
-        if (this.internal.created) {
-            return Promise.resolve();
-        } else {
-            return new Promise<void>((resolve, reject) => this.internal.enqueueCreatedPromise({ resolve, reject }));
-        }
-    }
-
-    /**
      * Destroys the actor.
      */
     public destroy(): void {
@@ -526,8 +515,8 @@ export class Actor implements ActorLike, Patchable<ActorLike> {
      * @param animationName The name of the animation.
      * @param options The animation keyframes, events, and other characteristics.
      */
-    public createAnimation(animationName: string, options: CreateAnimationOptions): Promise<void> {
-        return this.context.internal.createAnimation(this.id, animationName, options);
+    public createAnimation(animationName: string, options: CreateAnimationOptions) {
+        this.context.internal.createAnimation(this.id, animationName, options);
     }
 
     /**
@@ -721,10 +710,7 @@ export class Actor implements ActorLike, Patchable<ActorLike> {
         if (this.internal.observing) {
             this.internal.patch = this.internal.patch || {} as ActorLike;
             readPath(this, this.internal.patch, ...path);
-            // Wait until the actor has been created before triggering a state update.
-            this.created()
-                .then(() => this.context.internal.incrementGeneration())
-                .catch(reason => log.error('app', reason));
+            this.context.internal.incrementGeneration();
         }
     }
 

--- a/packages/sdk/src/types/runtime/soundInstance.ts
+++ b/packages/sdk/src/types/runtime/soundInstance.ts
@@ -25,18 +25,11 @@ export class SoundInstance {
         ForwardPromise<SoundInstance> {
         return createForwardPromise(this,
             new Promise<SoundInstance>((resolve, reject) => {
-                this.actor.created().then(() => {
-                    this.actor.context.assetManager.assetLoaded(this.soundAssetId).then(() => {
-                        this.actor.context.internal.setSoundState(
-                            this, SoundCommand.Start, options, this.soundAssetId, startTimeOffset);
+                this.actor.context.assetManager.assetLoaded(this.soundAssetId).then(() => {
+                    this.actor.context.internal.setSoundState(
+                        this, SoundCommand.Start, options, this.soundAssetId, startTimeOffset);
 
-                        resolve();
-                    }).catch((reason: any) => {
-                        log.error(
-                            'app',
-                            `Failed StartSound on actor ${this.actor.id}. ${(reason || '').toString()}`.trim());
-                        reject();
-                    });
+                    resolve();
                 }).catch((reason: any) => {
                     log.error(
                         'app',
@@ -48,19 +41,14 @@ export class SoundInstance {
     }
 
     public setSoundState(options: SetSoundStateOptions, soundCommand?: SoundCommand) {
-        this.actor.created().then(() => {
-            this.actor.context.assetManager.assetLoaded(this.soundAssetId).then(() => {
-                if (soundCommand === undefined) {
-                    soundCommand = SoundCommand.Update;
-                }
-                this.actor.context.internal.setSoundState(this, soundCommand, options);
-            }).catch((reason: any) => {
-                log.error('app', `SetSoundState failed ${this.actor.id}. ${(reason || '').toString()}`.trim());
-            });
+        this.actor.context.assetManager.assetLoaded(this.soundAssetId).then(() => {
+            if (soundCommand === undefined) {
+                soundCommand = SoundCommand.Update;
+            }
+            this.actor.context.internal.setSoundState(this, soundCommand, options);
         }).catch((reason: any) => {
             log.error('app', `SetSoundState failed ${this.actor.id}. ${(reason || '').toString()}`.trim());
         });
-
     }
 
     public pause() {


### PR DESCRIPTION
With this change, the SDK no longer waits for actor creation to complete before sending subsequent actor commands. The same for create-animation, etc. All messages are sent to the client where they're handled appropriately depending on the state of the actor. This greatly simplifies the multipeer sync layer, as well as lowering the SDK's need for reply messages overall.

PONDER: Should the asset system do something similar? What about interdependencies between the two systems?