### PR TITLE
moved 'behavior needs collider' warning to happen after actor created

### DIFF
--- a/packages/sdk/src/types/internal/context.ts
+++ b/packages/sdk/src/types/internal/context.ts
@@ -723,6 +723,10 @@ export class InternalContext {
         const actor = this.actorSet[actorId];
         if (actor) {
             actor.created().then(() => {
+                if (!actor.collider) {
+                    log.warning('app', 'Behaviors will not function on Unity host apps without adding a collider '
+                        + 'to this actor first. Recommend adding a primitive collider to this actor.');
+                }
                 this.protocol.sendPayload({
                     type: 'set-behavior',
                     actorId,

--- a/packages/sdk/src/types/runtime/actor.ts
+++ b/packages/sdk/src/types/runtime/actor.ts
@@ -492,11 +492,6 @@ export class Actor implements ActorLike, Patchable<ActorLike> {
      * @param behavior The type of behavior to set. Pass null to clear the behavior.
      */
     public setBehavior<BehaviorT extends Behavior>(behavior: { new(): BehaviorT }): BehaviorT {
-        if (!this.collider) {
-            log.warning('app', 'Behaviors will not function on Unity host apps without adding a collider to this actor '
-                + 'first. Recommend adding a primitive collider to this actor.');
-        }
-
         if (behavior) {
             const newBehavior = new behavior();
             this.internal.behavior = newBehavior;


### PR DESCRIPTION
if you created the behavior before actor had resolved, this warning would have triggered unnecessarily.

(After doing this, realized it may be affected by your refactor, Eric)