### PR TITLE
Add util to parse network logs into an event diagram

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "lint": "tslint -p ./packages/tsconfig.lint.json",
     "lint-docs": "lerna run lint-docs",
     "publish": "lerna publish",
-    "start": "node ./packages/functional-tests/"
+    "start": "node ./packages/functional-tests/",
+    "parseLogs": "node ./packages/sdk/built/utils/parseNetworkLogs.js"
   },
   "devDependencies": {
     "lerna": "3.4.2",

--- a/packages/functional-tests/src/app.ts
+++ b/packages/functional-tests/src/app.ts
@@ -76,7 +76,7 @@ export class App {
         this.connectedUsers[user.id] = user;
         if (!this.firstUser) {
             this.firstUser = user;
-            if (this.params.autorun !== undefined) {
+            if (this.params.autorun === 'true' || this.params.nomenu === 'true') {
                 this.runTest(user);
             }
         }
@@ -196,6 +196,11 @@ export class App {
                 }
             }
         }).value;
+
+        if (this.params.nomenu === 'true') {
+            this.runnerActors = [this.contextLabel];
+            return;
+        }
 
         // start or stop the active test
         const ppMat = this.context.assetManager.createMaterial('pp', {

--- a/packages/sdk/src/utils/parseNetworkLogs.ts
+++ b/packages/sdk/src/utils/parseNetworkLogs.ts
@@ -1,0 +1,98 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { readFile as readFileNodeAsync } from 'fs';
+import { resolve } from 'path';
+import { promisify } from 'util';
+const readFile = promisify(readFileNodeAsync);
+
+import safeAccessPath from './safeAccessPath';
+
+interface LogEvent {
+    input: string;
+    timestamp: number;
+    client: string;
+    direction?: 'to' | 'from';
+    networkContents?: any;
+}
+
+async function main(filename: string) {
+    const events = await parseFile(filename);
+    for (let e of events.filter(e => !/heartbeat/.test(e.networkContents.payloadType))) {
+        console.log(formatEvent(e));
+    }
+}
+
+async function parseFile(filename: string): Promise<LogEvent[]> {
+    const fileContents = await readFile(resolve(process.cwd(), filename), { encoding: 'utf8' });
+    const lines = fileContents.split('\n');
+    const events = [] as LogEvent[];
+
+    for (let i = 0; i < lines.length; i++) {
+        if (!/\bnetwork-content\b/.test(lines[i])) {
+            continue;
+        }
+
+        const e = parseEvent(lines[i - 1], lines[i]);
+        if (e !== null) {
+            events.push(e);
+        }
+    }
+
+    return events;
+}
+
+function parseEvent(network: string, contents: string): LogEvent {
+    const e = {
+        input: network + '\n' + contents,
+        timestamp: Date.parse(network.split(' ', 2)[0]),
+        client: '',
+        networkContents: JSON.parse(contents.slice(contents.indexOf('{')));
+    } as LogEvent;
+
+    let matches: string[];
+    if (matches = /\bclient ([0-9a-f]{8})\b/.exec(network)) {
+        e.client = matches[1];
+    } else if (/\bSession/.test(network)) {
+        e.client = 'session';
+    } else {
+        return null;
+    }
+
+    if (/\brecv\b/.test(network)) {
+        e.direction = 'from';
+    } else if (/\bsend\b/.test(network)) {
+        e.direction = 'to';
+    }
+
+    return e;
+}
+
+var columns = ['session'];
+const colWidth = 30;
+function formatEvent(event: LogEvent): string {
+    if (!columns.includes(event.client)) {
+        columns.push(event.client);
+    }
+
+    const props = {
+        messageId: event.networkContents.messageId.slice(0, 8),
+        replyToId: (event.networkContents.replyToId || '').slice(0, 8),
+        payloadType: event.networkContents.payloadType,
+        assetName: safeAccessPath(event.networkContents, 'payload', 'definition', 'name') as string
+    }
+
+    if (event.client === 'session') {
+        const dir = event.direction === 'to' ? '<=' : '=>';
+        return `(${props.messageId}) ${props.payloadType} ${props.assetName}${dir} ${props.replyToId}`;
+    } else {
+        const replyTo = props.replyToId ? `(${props.replyToId}) ` : '';
+        const indentation = ' '.repeat(-replyTo.length + colWidth * columns.indexOf(event.client));
+        const dir = event.direction === 'from' ? '<=' : '=>';
+        return `${indentation}${replyTo}${dir} (${props.messageId}) ${props.payloadType} ${props.assetName}`;
+    }
+}
+
+main(process.argv[2] || null).catch(e => console.error(e));

--- a/packages/sdk/src/utils/safeAccessPath.ts
+++ b/packages/sdk/src/utils/safeAccessPath.ts
@@ -1,0 +1,15 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export default function safeAccessPath(obj: any, ...path: any[]): any {
+    for (let i = 0; i < path.length; i++) {
+        if (!obj[path[i]]) {
+            return undefined;
+        } else {
+            obj = obj[path[i]];
+        }
+    }
+    return obj;
+}

--- a/packages/sdk/src/utils/safeAccessPath.ts
+++ b/packages/sdk/src/utils/safeAccessPath.ts
@@ -4,11 +4,11 @@
  */
 
 export default function safeAccessPath(obj: any, ...path: any[]): any {
-    for (let i = 0; i < path.length; i++) {
-        if (!obj[path[i]]) {
+    for (const part of path) {
+        if (!obj[part]) {
             return undefined;
         } else {
-            obj = obj[path[i]];
+            obj = obj[part];
         }
     }
     return obj;


### PR DESCRIPTION
Its output is pretty rough, but it serves its purpose. For a single app session, plus for each connected client, the script outputs a column of incoming and outgoing messages, sorted chronologically.

```
15:00:40 (ebfe09) create-primitive =>
15:00:40                               => (ebfe09) create-primitive
15:00:40                                                             => (ebfe09) create-primitive
15:00:40                                                    (ebfe09) <= (8d32b8) object-spawned
15:00:40                      (ebfe09) <= (2ce3c6) object-spawned
15:00:40 (2ce3c6) object-spawned <= ebfe09

```