### PR TITLE
Separate out serialized appearance.enabled field

### DIFF
--- a/packages/sdk/src/types/runtime/appearance.ts
+++ b/packages/sdk/src/types/runtime/appearance.ts
@@ -116,6 +116,9 @@ export class Appearance implements AppearanceLike {
         if (from.materialId !== undefined) this.materialId = from.materialId;
         if (from.enabledPacked !== undefined) {
             this.enabledPacked = from.enabledPacked;
+        } else if (typeof from.enabled === 'number') {
+            // redirect masks that got into the enabled field
+            this.enabledPacked = from.enabled;
         } else if (from.enabled !== undefined) {
             this.enabled = from.enabled;
         }

--- a/packages/sdk/src/types/runtime/appearance.ts
+++ b/packages/sdk/src/types/runtime/appearance.ts
@@ -12,7 +12,11 @@ export interface AppearanceLike {
      * GroupMask object, this property will effectively be `true` for users in at least one
      * of the groups, and `false` for everyone else. See [[GroupMask]].
      */
-    enabled: boolean | number | GroupMask;
+    enabled: boolean | GroupMask;
+
+    /** @hidden */
+    enabledPacked: number;
+
     /**
      * The ID of a previously-created [[Material]] asset.
      */
@@ -24,8 +28,8 @@ export class Appearance implements AppearanceLike {
     public $DoNotObserve = ['actor', '_enabledFor'];
 
     // tslint:disable:variable-name
-    private _enabled = GroupMask.ALL_PACKED; // authoritative
-    private _enabledFor: GroupMask; // cached object, synced with _enabled
+    private _enabledPacked = GroupMask.ALL_PACKED; // authoritative
+    private _enabledFor: GroupMask; // cached object, synced with _enabledPacked
     private _materialId = ZeroGuid;
     // tslint:enable:variable-name
 
@@ -61,20 +65,21 @@ export class Appearance implements AppearanceLike {
      */
     public get enabledFor() {
         if (!this._enabledFor) {
-            this._enabledFor = GroupMask.FromPacked(this.actor.context, this._enabled);
-            this._enabledFor.onChanged(gm => this._enabled = gm.packed());
+            this._enabledFor = GroupMask.FromPacked(this.actor.context, this._enabledPacked);
+            this._enabledFor.onChanged(gm => this._enabledPacked = gm.packed());
         }
         return this._enabledFor;
     }
     public set enabledFor(value) {
         this.enabledPacked = value.packed();
         this._enabledFor = value;
-        this._enabledFor.onChanged(gm => this._enabled = gm.packed());
+        this._enabledFor.onChanged(gm => this._enabledPacked = gm.packed());
     }
 
-    private get enabledPacked() { return this._enabled; }
-    private set enabledPacked(value: number) {
-        this._enabled = value;
+    /** @hidden */
+    public get enabledPacked() { return this._enabledPacked; }
+    public set enabledPacked(value: number) {
+        this._enabledPacked = value;
         if (this._enabledFor) {
             this._enabledFor.setPacked(value);
         }
@@ -83,7 +88,7 @@ export class Appearance implements AppearanceLike {
     /** Whether this actor is visible */
     public get activeAndEnabled(): boolean {
         return (!this.actor.parent || this.actor.parent.appearance.activeAndEnabled)
-            && this._enabled !== GroupMask.NONE_PACKED;
+            && this._enabledPacked !== GroupMask.NONE_PACKED;
     }
 
     /** @returns A shared reference to this actor's material, or null if this actor has no material */
@@ -109,19 +114,17 @@ export class Appearance implements AppearanceLike {
     public copy(from: Partial<AppearanceLike>): this {
         if (!from) return this;
         if (from.materialId !== undefined) this.materialId = from.materialId;
-        if (from.enabled !== undefined) {
-            if (typeof from.enabled === 'number') {
-                this.enabledPacked = from.enabled;
-            } else {
-                this.enabled = from.enabled;
-            }
+        if (from.enabledPacked !== undefined) {
+            this.enabledPacked = from.enabledPacked;
+        } else if (from.enabled !== undefined) {
+            this.enabled = from.enabled;
         }
         return this;
     }
 
     public toJSON() {
         return {
-            enabled: this.enabledPacked,
+            enabledPacked: this.enabledPacked,
             materialId: this.materialId
         } as AppearanceLike;
     }


### PR DESCRIPTION
The patch was still sending down `true` and `false`, causing a parse error Unity-side. This make sure that it's only sending down numbers.