### PR TITLE
[SDK] Misc synchronization fixes and improvements

### DIFF
--- a/packages/sdk/src/adapters/multipeer/protocols/clientSync.ts
+++ b/packages/sdk/src/adapters/multipeer/protocols/clientSync.ts
@@ -80,6 +80,12 @@ export class ClientSync extends Protocols.Protocol {
         }
     }
 
+    /** @override */
+    protected missingPromiseForReplyMessage(message: Message) {
+        // Ignore. Sync protocol receives reply messages for create-* messages, but doesn't queue
+        // completion promises for them because it doesn't care about when they complete.
+    }
+
     private handlingForMessage(message: Message) {
         const rule = Rules[message.payload.type] || MissingRule;
         let handling = rule.synchronization.before;

--- a/packages/sdk/src/adapters/multipeer/rules.ts
+++ b/packages/sdk/src/adapters/multipeer/rules.ts
@@ -217,8 +217,9 @@ export const Rules: { [id in Payloads.PayloadType]: Rule } = {
             }
         },
         session: {
-            // Whenever we encounter an actor-correction, convert it to an actor-update
-            // Eventually: Remove actor-correction payload type (requires DLL change).
+            // For now, whenever we encounter an actor-correction, convert it to an actor-update.
+            // Later this message type might be utilized to indicate that actor values should be
+            // interpolated rather than overwritten.
             beforeReceiveFromApp: (
                 session: Session,
                 message: Message<Payloads.ActorUpdate>
@@ -867,7 +868,7 @@ export const Rules: { [id in Payloads.PayloadType]: Rule } = {
         synchronization: {
             stage: 'set-behaviors',
             before: 'ignore',
-            during: 'queue',
+            during: 'allow',
             after: 'allow'
         },
         session: {

--- a/packages/sdk/src/protocols/execution.ts
+++ b/packages/sdk/src/protocols/execution.ts
@@ -4,7 +4,7 @@
  */
 
 import { Protocol, ServerPreprocessing } from '.';
-import { ActionEvent, CollisionEvent, Context, WebSocket } from '..';
+import { ActionEvent, CollisionEvent, Context, Message, WebSocket } from '..';
 import {
     ActorUpdate,
     CollisionEventRaised,
@@ -33,6 +33,11 @@ export class Execution extends Protocol {
         super(context.conn);
         // Behave like a server-side endpoint (send heartbeats, measure connection quality)
         this.use(new ServerPreprocessing());
+    }
+
+    /** @override */
+    protected missingPromiseForReplyMessage(message: Message) {
+        // Ignore. App receives reply messages from all clients, but only processes the first one.
     }
 
     /** @private */


### PR DESCRIPTION
- Fixed a misconfiguration in the set-behaviors sync stage.
- Made it easier to selectively treat unexpected reply messages as non-errors.
- Clarified a comment about the status of the actor-correction payload.