### PR TITLE
Log system improvements

### DIFF
--- a/packages/sdk/src/adapters/multipeer/client.ts
+++ b/packages/sdk/src/adapters/multipeer/client.ts
@@ -110,7 +110,7 @@ export class Client extends EventEmitter {
             this.protocol.sendMessage(message, promise);
         } else {
             // tslint:disable-next-line:no-console
-            console.error(`[ERROR] No protocol for message send: ${message.payload.type}`);
+            log.error('network', `[ERROR] No protocol for message send: ${message.payload.type}`);
         }
     }
 
@@ -119,7 +119,7 @@ export class Client extends EventEmitter {
             this.protocol.sendPayload(payload, promise);
         } else {
             // tslint:disable-next-line:no-console
-            console.error(`[ERROR] No protocol for payload send: ${payload.type}`);
+            log.error('network', `[ERROR] No protocol for payload send: ${payload.type}`);
         }
     }
 

--- a/packages/sdk/src/adapters/multipeer/protocols/clientSync.ts
+++ b/packages/sdk/src/adapters/multipeer/protocols/clientSync.ts
@@ -75,7 +75,7 @@ export class ClientSync extends Protocols.Protocol {
             }
             case 'error': {
                 // tslint:disable-next-line: max-line-length
-                console.error(`[ERROR] ${this.name}: Invalid message for send during synchronization stage: ${message.payload.type}. In progress: ${this.inProgressStages.join(',')}. Complete: ${this.completedStages.join(',')}.`);
+                log.error('network', `[ERROR] ${this.name}: Invalid message for send during synchronization stage: ${message.payload.type}. In progress: ${this.inProgressStages.join(',')}. Complete: ${this.completedStages.join(',')}.`);
             }
         }
     }
@@ -121,7 +121,7 @@ export class ClientSync extends Protocols.Protocol {
         if (handler) {
             await handler(); // Allow exception to propagate.
         } else {
-            console.error(`[ERROR] ${this.name}: No handler for stage ${stage}!`);
+            log.error('network', `[ERROR] ${this.name}: No handler for stage ${stage}!`);
         }
     }
 

--- a/packages/sdk/src/adapters/multipeer/rules.ts
+++ b/packages/sdk/src/adapters/multipeer/rules.ts
@@ -6,6 +6,7 @@
 import deepmerge from 'deepmerge';
 import { Client, Session, SynchronizationStage } from '.';
 import { Message, WebSocket } from '../..';
+import { log } from '../../log';
 import { SoundCommand } from '../../sound';
 import * as Payloads from '../../types/network/payloads';
 import { ExportedPromise } from '../../utils/exportedPromise';
@@ -142,19 +143,19 @@ export const MissingRule: Rule = {
     client: {
         beforeQueueMessageForClient: (
             session: Session, client: Client, message: any, promise: ExportedPromise) => {
-            console.error(`[ERROR] No rule defined for payload ${message.payload.type}! Add an entry in rules.ts.`);
+            log.error('app', `[ERROR] No rule defined for payload ${message.payload.type}! Add an entry in rules.ts.`);
             return message;
         }
     },
     session: {
         beforeReceiveFromApp: (
             session: Session, message: Message) => {
-            console.error(`[ERROR] No rule defined for payload ${message.payload.type}! Add an entry in rules.ts.`);
+            log.error('app', `[ERROR] No rule defined for payload ${message.payload.type}! Add an entry in rules.ts.`);
             return message;
         },
         beforeReceiveFromClient: (
             session: Session, client: Client, message: Message) => {
-            console.error(`[ERROR] No rule defined for payload ${message.payload.type}! Add an entry in rules.ts.`);
+            log.error('app', `[ERROR] No rule defined for payload ${message.payload.type}! Add an entry in rules.ts.`);
             return message;
         },
     }
@@ -175,14 +176,14 @@ const ClientOnlyRule: Rule = {
     client: {
         beforeQueueMessageForClient: (
             session: Session, client: Client, message: any, promise: ExportedPromise) => {
-            console.error(`[ERROR] session tried to queue a client-only message: ${message.payload.type}!`);
+            log.error('network', `[ERROR] session tried to queue a client-only message: ${message.payload.type}!`);
             return message;
         }
     },
     session: {
         ...DefaultRule.session,
         beforeReceiveFromApp: (session: Session, message: Message) => {
-            console.error(`[ERROR] app tried to send a client-only message: ${message.payload.type}!`);
+            log.error('network', `[ERROR] app tried to send a client-only message: ${message.payload.type}!`);
             return undefined;
         }
     }

--- a/packages/sdk/src/adapters/multipeer/session.ts
+++ b/packages/sdk/src/adapters/multipeer/session.ts
@@ -158,7 +158,7 @@ export class Session extends EventEmitter {
     private setAuthoritativeClient(clientId: string) {
         if (!this._clientSet[clientId]) {
             // tslint:disable-next-line:no-console
-            console.error(`[ERROR] setAuthoritativeClient: client ${clientId} does not exist.`);
+            log.error('network', `[ERROR] setAuthoritativeClient: client ${clientId} does not exist.`);
         }
         this._clientSet[clientId].setAuthoritative(true);
         this.clients

--- a/packages/sdk/src/protocols/protocol.ts
+++ b/packages/sdk/src/protocols/protocol.ts
@@ -159,12 +159,12 @@ export class Protocol extends EventEmitter {
         if (payload && payload.type && payload.type.length) {
             const handler = (this as any)[`recv-${payload.type}`] || (() => {
                 // tslint:disable-next-line:no-console
-                console.error(`[ERROR] ${this.name} has no handler for payload ${payload.type}!`);
+                log.error('network', `[ERROR] ${this.name} has no handler for payload ${payload.type}!`);
             });
             handler(payload);
         } else {
             // tslint:disable-next-line:no-console
-            console.error(`[ERROR] ${this.name} invalid message payload!`);
+            log.error('network', `[ERROR] ${this.name} invalid message payload!`);
         }
     }
 
@@ -211,7 +211,7 @@ export class Protocol extends EventEmitter {
 
     protected missingPromiseForReplyMessage(message: Message) {
         // tslint:disable-next-line:no-console max-line-length
-        console.error(`[ERROR] ${this.name} received unexpected reply message! payload: ${message.payload.type}, replyToId: ${message.replyToId}`);
+        log.error('network', `[ERROR] ${this.name} received unexpected reply message! payload: ${message.payload.type}, replyToId: ${message.replyToId}`);
     }
 
     private onReceive = (message: Message) => {

--- a/packages/sdk/src/webHost.ts
+++ b/packages/sdk/src/webHost.ts
@@ -31,8 +31,8 @@ export class WebHost {
         options: { baseDir?: string, baseUrl?: string, port?: string | number } = {}
     ) {
         const pjson = require('../package.json');
-        log.logToApp(`Node: ${process.version}`);
-        log.logToApp(`${pjson.name}: v${pjson.version}`);
+        log.info('app', `Node: ${process.version}`);
+        log.info('app', `${pjson.name}: v${pjson.version}`);
 
         this._baseDir = options.baseDir || process.env.BASE_DIR;
         this._baseUrl = options.baseUrl || process.env.BASE_URL;
@@ -52,9 +52,9 @@ export class WebHost {
         this._adapter.listen()
             .then(server => {
                 this._baseUrl = this._baseUrl || server.url.replace(/\[::\]/, '127.0.0.1');
-                log.logToApp(`${server.name} listening on ${JSON.stringify(server.address())}`);
-                log.logToApp(`baseUrl: ${this.baseUrl}`);
-                log.logToApp(`baseDir: ${this.baseDir}`);
+                log.info('app', `${server.name} listening on ${JSON.stringify(server.address())}`);
+                log.info('app', `baseUrl: ${this.baseUrl}`);
+                log.info('app', `baseDir: ${this.baseDir}`);
                 if (!!this.baseDir) {
                     this.serveStaticFiles(server);
                 }


### PR DESCRIPTION
The logging system can now be configured from the `MRE_LOGGING` environment variable.

Simple example:
```bash
# Enable 'app', 'network' and 'network-content' logging
MRE_LOGGING=app,network,network-content
```

You can disable logging by area by prefixing with a `-`:
```bash
# Disable 'app' logging
MRE_LOGGING=-app
```

You can be selective about the severity levels to enable and disable:
```bash
# Disable 'app:info', enable 'network:error'
MRE_LOGGING=-app:info,network:error
```

Also: Replaced calls to console.error with calls to logging system.