### PR TITLE
[DO NOT MERGE] User-exclusive actors v2

### DIFF
--- a/packages/sdk/src/adapters/multipeer/README.md
+++ b/packages/sdk/src/adapters/multipeer/README.md
@@ -26,7 +26,7 @@ On connection:
     1. Run `ClientSync` to re-send session state messages
     2. Register new `ClientExecution` protocol and `startListening`
 
-On message expecting a reply, when the client is synchronized:
+On message expecting a reply, after the client is synchronized. Everything is the same if not synchronized, except `ClientExecution` is `ClientSync`, and instead of 11.2 sending 
 
 1. `InternalContext::createActorFromPayload` with a `CreateEmpty` payload or similar
 2. `Execution::sendPayload` calls `Execution::sendMessage`
@@ -48,14 +48,14 @@ On message expecting a reply, when the client is synchronized:
     1. `Client::send` calls `ClientExecution::sendMessage`
     2. `ClientExecution::sendMessage` runs middlewares
         1. `ServerPreprocessing::beforeSend` adds `serverTimeMs` to messages if not present
-    4. `ClientExecution#conn::send` sends message over the websocket
-    5. The remote client does some work, and sends an `ObjectSpawned` message
-    6. `ClientExecution::onReceive` calls `ClientExecution::recvMessage`
-    7. `ClientExecution::recvMessage` runs middlewares
+    3. `ClientExecution#conn::send` sends message over the websocket
+    4. The remote client does some work, and sends an `ObjectSpawned` message
+    5. `ClientExecution::onReceive` calls `ClientExecution::recvMessage`
+    6. `ClientExecution::recvMessage` runs middlewares
         1. `ClientExecution::beforeRecv` continues standard protocol flow if there's a callback waiting for this message, which never happens when messages come from a session. In this case, flow goes to `ClientExecution::handleReplyMessage` if there is a reply ID indicated, or `ClientExecution::recvPayload` if not.
-    8. `ClientExecution::beforeRecv` emits `recv` event
-    9. `recv` picked up by `Session::recvFromClient`
-    10. `Session::preprocessFromClient`
+    7. `ClientExecution::beforeRecv` emits `recv` event
+    8. `recv` picked up by `Session::recvFromClient`
+    9. `Session::preprocessFromClient`
         1. Look up rule for payload type from `Rules`
         2. `Rule#session::beforeReceiveFromClient`
         3. For `ObjectSpawned` messages, if from authoritative peer, copy each returned actor description into the session state and continue to send message to app. Otherwise stop processing this message.

--- a/packages/sdk/src/adapters/multipeer/client.ts
+++ b/packages/sdk/src/adapters/multipeer/client.ts
@@ -34,6 +34,7 @@ export class Client extends EventEmitter {
     private _protocol: Protocols.Protocol;
     private _order: number;
     private _queuedMessages: QueuedMessage[] = [];
+    private _userExclusiveMessages: Message[] = [];
     private _authoritative = false;
     // tslint:enable:variable-name
 
@@ -44,6 +45,7 @@ export class Client extends EventEmitter {
     public get conn() { return this._conn; }
     public get authoritative() { return this._authoritative; }
     public get queuedMessages() { return this._queuedMessages; }
+    public get userExclusiveMessages() { return this._userExclusiveMessages; }
 
     public userId: string;
 

--- a/packages/sdk/src/adapters/multipeer/client.ts
+++ b/packages/sdk/src/adapters/multipeer/client.ts
@@ -34,7 +34,7 @@ export class Client extends EventEmitter {
     private _protocol: Protocols.Protocol;
     private _order: number;
     private _queuedMessages: QueuedMessage[] = [];
-    private _userExclusiveMessages: Message[] = [];
+    private _userExclusiveMessages: QueuedMessage[] = [];
     private _authoritative = false;
     // tslint:enable:variable-name
 

--- a/packages/sdk/src/adapters/multipeer/clientDesyncPreprocessor.ts
+++ b/packages/sdk/src/adapters/multipeer/clientDesyncPreprocessor.ts
@@ -3,9 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import { Client } from '.';
-import { Middleware } from '../../protocols';
+import { Client, Rules } from '.';
 import { Message } from '../..';
+import { Middleware } from '../../protocols';
+import { UserJoined } from '../../types/network/payloads';
 import { ExportedPromise } from '../../utils/exportedPromise';
 
 /**
@@ -16,6 +17,30 @@ export class ClientDesyncPreprocessor implements Middleware {
     constructor(private client: Client) { }
     /** @hidden */
     public beforeSend(message: Message, promise?: ExportedPromise): Message {
+        const payloadType = message.payload.type;
+        const forUser = Rules[payloadType].client.shouldSendToUser(
+            message, this.client.userId, this.client.session, this.client);
+        if (forUser !== null && !this.client.userId) {
+            // this message is user-exclusive, and the client's user ID is not yet settled,
+            // queue and cancel send for now
+            this.client.userExclusiveMessages.push({ message, promise });
+        } else if (forUser !== false && this.client.userId) {
+            // this message is intended for this client's user, send now
+            return message;
+        }
+        // this message is intended for a different user, discard
+    }
+
+    /** @hidden */
+    public beforeRecv(message: Message): Message {
+        if (message.payload.type === 'user-joined') {
+            const userJoin = message.payload as UserJoined;
+            this.client.userId = userJoin.user.id;
+            while (this.client.userExclusiveMessages.length > 0) {
+                const queuedMsg = this.client.userExclusiveMessages.splice(0, 1)[0];
+                this.client.send(queuedMsg.message, queuedMsg.promise);
+            }
+        }
         return message;
     }
 }

--- a/packages/sdk/src/adapters/multipeer/clientDesyncPreprocessor.ts
+++ b/packages/sdk/src/adapters/multipeer/clientDesyncPreprocessor.ts
@@ -1,0 +1,21 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { Client } from '.';
+import { Middleware } from '../../protocols';
+import { Message } from '../..';
+import { ExportedPromise } from '../../utils/exportedPromise';
+
+/**
+ * Filter user-exclusive actors to a queue, then flush them after user-join
+ * @hidden
+ */
+export class ClientDesyncPreprocessor implements Middleware {
+    constructor(private client: Client) { }
+    /** @hidden */
+    public beforeSend(message: Message, promise?: ExportedPromise): Message {
+        return message;
+    }
+}

--- a/packages/sdk/src/adapters/multipeer/index.ts
+++ b/packages/sdk/src/adapters/multipeer/index.ts
@@ -9,3 +9,4 @@ export * from './client';
 export * from './syncActor';
 export * from './protocols';
 export * from './rules';
+export * from './clientDesyncPreprocessor';

--- a/packages/sdk/src/adapters/multipeer/protocols/clientExecution.ts
+++ b/packages/sdk/src/adapters/multipeer/protocols/clientExecution.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { Client } from '..';
+import { Client, ClientDesyncPreprocessor } from '..';
 import { Message } from '../../..';
 import * as Protocols from '../../../protocols';
 
@@ -28,6 +28,8 @@ export class ClientExecution extends Protocols.Protocol implements Protocols.Mid
         this.beforeRecv = this.beforeRecv.bind(this);
         // Behave like a server-side endpoint (send heartbeats, measure connection quality)
         this.use(new Protocols.ServerPreprocessing());
+        // Filter user-exclusive actors
+        this.use(new ClientDesyncPreprocessor(client));
         // Use middleware to pipe client messages to the session.
         this.use(this);
     }

--- a/packages/sdk/src/adapters/multipeer/protocols/clientSync.ts
+++ b/packages/sdk/src/adapters/multipeer/protocols/clientSync.ts
@@ -51,6 +51,7 @@ export class ClientSync extends Protocols.Protocol {
         super(client.conn);
         // Behave like a server-side endpoint (send heartbeats, measure connection quality)
         this.use(new Protocols.ServerPreprocessing());
+        // Queue up user-exclusive messages until the user has joined
         this.use(new ClientDesyncPreprocessor(client));
     }
 

--- a/packages/sdk/src/adapters/multipeer/protocols/clientSync.ts
+++ b/packages/sdk/src/adapters/multipeer/protocols/clientSync.ts
@@ -4,7 +4,7 @@
  */
 
 import UUID from 'uuid/v4';
-import { Client, MissingRule, Rules, SyncActor } from '..';
+import { Client, ClientDesyncPreprocessor, MissingRule, Rules, SyncActor } from '..';
 import { Message } from '../../..';
 import { log } from '../../../log';
 import * as Protocols from '../../../protocols';
@@ -51,6 +51,7 @@ export class ClientSync extends Protocols.Protocol {
         super(client.conn);
         // Behave like a server-side endpoint (send heartbeats, measure connection quality)
         this.use(new Protocols.ServerPreprocessing());
+        this.use(new ClientDesyncPreprocessor(client));
     }
 
     /**

--- a/packages/sdk/src/adapters/multipeer/rules.ts
+++ b/packages/sdk/src/adapters/multipeer/rules.ts
@@ -207,6 +207,37 @@ const ClientOnlyRule: Rule = {
 
 /**
  * @hidden
+ * Handling for actor creation messages
+ */
+const CreateActorRule: Rule = {
+    ...DefaultRule,
+    synchronization: {
+        stage: 'create-actors',
+        before: 'ignore',
+        during: 'queue',
+        after: 'allow'
+    },
+    client: {
+        ...DefaultRule.client,
+        shouldSendToUser: (message: Message<Payloads.CreateActorCommon>, userId, session, client) => {
+            const actorUser = session.actorSet[message.payload.actor.id].exclusiveToUser;
+            return actorUser ? actorUser === userId : null;
+        }
+    },
+    session: {
+        ...DefaultRule.session,
+        beforeReceiveFromApp: (
+            session: Session,
+            message: Message<Payloads.CreateEmpty>
+        ) => {
+            session.cacheCreateActorMessage(message);
+            return message;
+        }
+    }
+};
+
+/**
+ * @hidden
  * A global collection of message rules used by different parts of the multipeer adapter.
  * Getting a compiler error here? It is likely that `Rules` is missing a rule for the new payload type you added.
  * *** KEEP ENTRIES SORTED ***
@@ -462,109 +493,19 @@ export const Rules: { [id in Payloads.PayloadType]: Rule } = {
     },
 
     // ========================================================================
-    'create-empty': {
-        ...DefaultRule,
-        synchronization: {
-            stage: 'create-actors',
-            before: 'ignore',
-            during: 'queue',
-            after: 'allow'
-        },
-        session: {
-            ...DefaultRule.session,
-            beforeReceiveFromApp: (
-                session: Session,
-                message: Message<Payloads.CreateEmpty>
-            ) => {
-                session.cacheCreateActorMessage(message);
-                return message;
-            }
-        }
-    },
+    'create-empty': CreateActorRule,
 
     // ========================================================================
-    'create-from-gltf': {
-        ...DefaultRule,
-        synchronization: {
-            stage: 'create-actors',
-            before: 'ignore',
-            during: 'queue',
-            after: 'allow'
-        },
-        session: {
-            ...DefaultRule.session,
-            beforeReceiveFromApp: (
-                session: Session,
-                message: Message<Payloads.CreateFromGltf>
-            ) => {
-                session.cacheCreateActorMessage(message);
-                return message;
-            }
-        }
-    },
+    'create-from-gltf': CreateActorRule,
 
     // ========================================================================
-    'create-from-library': {
-        ...DefaultRule,
-        synchronization: {
-            stage: 'create-actors',
-            before: 'ignore',
-            during: 'queue',
-            after: 'allow'
-        },
-        session: {
-            ...DefaultRule.session,
-            beforeReceiveFromApp: (
-                session: Session,
-                message: Message<Payloads.CreateFromLibrary>
-            ) => {
-                session.cacheCreateActorMessage(message);
-                return message;
-            }
-        }
-    },
+    'create-from-library': CreateActorRule,
 
     // ========================================================================
-    'create-primitive': {
-        ...DefaultRule,
-        synchronization: {
-            stage: 'create-actors',
-            before: 'ignore',
-            during: 'queue',
-            after: 'allow'
-        },
-        session: {
-            ...DefaultRule.session,
-            beforeReceiveFromApp: (
-                session: Session,
-                message: Message<Payloads.CreatePrimitive>
-            ) => {
-                session.cacheCreateActorMessage(message);
-                return message;
-            }
-        }
-    },
+    'create-primitive': CreateActorRule,
 
     // ========================================================================
-    'create-from-prefab': {
-        ...DefaultRule,
-        synchronization: {
-            stage: 'create-actors',
-            before: 'ignore',
-            during: 'queue',
-            after: 'allow'
-        },
-        session: {
-            ...DefaultRule.session,
-            beforeReceiveFromApp: (
-                session: Session,
-                message: Message<Payloads.CreateFromPrefab>
-            ) => {
-                session.cacheCreateActorMessage(message);
-                return message;
-            }
-        }
-    },
+    'create-from-prefab': CreateActorRule,
 
     // ========================================================================
     'destroy-actors': {
@@ -590,19 +531,13 @@ export const Rules: { [id in Payloads.PayloadType]: Rule } = {
     },
 
     // ========================================================================
-    'engine2app-rpc': {
-        ...ClientOnlyRule
-    },
+    'engine2app-rpc': ClientOnlyRule,
 
     // ========================================================================
-    'handshake': {
-        ...ClientOnlyRule
-    },
+    'handshake': ClientOnlyRule,
 
     // ========================================================================
-    'handshake-complete': {
-        ...ClientOnlyRule
-    },
+    'handshake-complete': ClientOnlyRule,
 
     // ========================================================================
     'handshake-reply': {
@@ -627,9 +562,7 @@ export const Rules: { [id in Payloads.PayloadType]: Rule } = {
     },
 
     // ========================================================================
-    'heartbeat-reply': {
-        ...ClientOnlyRule
-    },
+    'heartbeat-reply': ClientOnlyRule,
 
     // ========================================================================
     'interpolate-actor': {
@@ -678,9 +611,7 @@ export const Rules: { [id in Payloads.PayloadType]: Rule } = {
     },
 
     // ========================================================================
-    'multi-operation-result': {
-        ...ClientOnlyRule
-    },
+    'multi-operation-result': ClientOnlyRule,
 
     // ========================================================================
     'object-spawned': {
@@ -1015,14 +946,10 @@ export const Rules: { [id in Payloads.PayloadType]: Rule } = {
     },
 
     // ========================================================================
-    'sync-request': {
-        ...ClientOnlyRule
-    },
+    'sync-request': ClientOnlyRule,
 
     // ========================================================================
-    'traces': {
-        ...ClientOnlyRule
-    },
+    'traces': ClientOnlyRule,
 
     // ========================================================================
     'update-subscriptions': {
@@ -1074,9 +1001,7 @@ export const Rules: { [id in Payloads.PayloadType]: Rule } = {
     },
 
     // ========================================================================
-    'user-left': {
-        ...ClientOnlyRule
-    },
+    'user-left': ClientOnlyRule,
 
     // ========================================================================
     'user-update': {

--- a/packages/sdk/src/adapters/multipeer/rules.ts
+++ b/packages/sdk/src/adapters/multipeer/rules.ts
@@ -102,6 +102,14 @@ export type Rule = {
          */
         beforeReceiveFromClient: (
             session: Session, client: Client, message: any) => Message;
+        /**
+         * Determines whether a given message should go to a given client. Called after beforeReceiveFromApp.
+         * @param session The current session.
+         * @param client The client who should be tested.
+         * @param message The message itself (also contains the payload).
+         * @returns `true` if this message should be sent to this client, or `false` if not.
+         */
+        shouldSendToClient: (session: Session, client: Client, message: any) => boolean;
     }
 };
 
@@ -131,6 +139,7 @@ export const DefaultRule: Rule = {
             session: Session, client: Client, message: Message) => {
             return message;
         },
+        shouldSendToClient: () => true,
     }
 };
 
@@ -148,6 +157,7 @@ export const MissingRule: Rule = {
         }
     },
     session: {
+        ...DefaultRule.session,
         beforeReceiveFromApp: (
             session: Session, message: Message) => {
             log.error('app', `[ERROR] No rule defined for payload ${message.payload.type}! Add an entry in rules.ts.`);
@@ -218,9 +228,9 @@ export const Rules: { [id in Payloads.PayloadType]: Rule } = {
             }
         },
         session: {
-            // For now, whenever we encounter an actor-correction, convert it to an actor-update.
-            // Later this message type might be utilized to indicate that actor values should be
-            // interpolated rather than overwritten.
+            ...DefaultRule.session,
+            // Whenever we encounter an actor-correction, convert it to an actor-update
+            // Eventually: Remove actor-correction payload type (requires DLL change).
             beforeReceiveFromApp: (
                 session: Session,
                 message: Message<Payloads.ActorUpdate>

--- a/packages/sdk/src/adapters/multipeer/rules.ts
+++ b/packages/sdk/src/adapters/multipeer/rules.ts
@@ -1062,9 +1062,6 @@ export const Rules: { [id in Payloads.PayloadType]: Rule } = {
                 client: Client,
                 message: Message<Payloads.UserJoined>
             ) => {
-                // Associate the client connection with the user id.
-                client.userId = message.payload.user.id;
-
                 // Add remote ip address to the joining user.
                 const props = message.payload.user.properties = message.payload.user.properties || {};
                 if (client.conn instanceof WebSocket && !props.remoteAddress) {

--- a/packages/sdk/src/adapters/multipeer/session.ts
+++ b/packages/sdk/src/adapters/multipeer/session.ts
@@ -203,17 +203,14 @@ export class Session extends EventEmitter {
         this.protocol.sendMessage(message);
     }
 
-    public sendToClients(message: Message, filterFn?: (value: Client) => any) {
-        const rule = Rules[message.payload.type] || MissingRule;
-        const ruleFilter = rule.session.shouldSendToClient || (() => true);
-        const sendFilter = filterFn || (() => true);
-        const clients = this.clients.filter(c => ruleFilter(this, c, message) && sendFilter(c));
+    public sendToClients(message: Message, filterFn?: (value: Client, index: number) => any) {
+        const clients = this.clients.filter(filterFn || (() => true));
         for (const client of clients) {
             client.send({ ...message });
         }
     }
 
-    public sendPayloadToClients(payload: Partial<Payloads.Payload>, filterFn?: (value: Client) => any) {
+    public sendPayloadToClients(payload: Partial<Payloads.Payload>, filterFn?: (value: Client, index: number) => any) {
         this.sendToClients({ payload }, filterFn);
     }
 

--- a/packages/sdk/src/adapters/multipeer/session.ts
+++ b/packages/sdk/src/adapters/multipeer/session.ts
@@ -240,6 +240,8 @@ export class Session extends EventEmitter {
             const createActor = deepmerge({ message }, {});
             syncActor = this.actorSet[message.payload.actor.id] = { created: createActor };
             syncActor.actorId = message.payload.actor.id;
+            syncActor.exclusiveToUser = message.payload.actor.exclusiveToUser ||
+                this.actorSet[message.payload.actor.parentId].exclusiveToUser;
         }
     }
 

--- a/packages/sdk/src/adapters/multipeer/session.ts
+++ b/packages/sdk/src/adapters/multipeer/session.ts
@@ -203,14 +203,17 @@ export class Session extends EventEmitter {
         this.protocol.sendMessage(message);
     }
 
-    public sendToClients(message: Message, filterFn?: (value: Client, index: number) => any) {
-        const clients = this.clients.filter(filterFn || (() => true));
+    public sendToClients(message: Message, filterFn?: (value: Client) => any) {
+        const rule = Rules[message.payload.type] || MissingRule;
+        const ruleFilter = rule.session.shouldSendToClient || (() => true);
+        const sendFilter = filterFn || (() => true);
+        const clients = this.clients.filter(c => ruleFilter(this, c, message) && sendFilter(c));
         for (const client of clients) {
             client.send({ ...message });
         }
     }
 
-    public sendPayloadToClients(payload: Partial<Payloads.Payload>, filterFn?: (value: Client, index: number) => any) {
+    public sendPayloadToClients(payload: Partial<Payloads.Payload>, filterFn?: (value: Client) => any) {
         this.sendToClients({ payload }, filterFn);
     }
 

--- a/packages/sdk/src/adapters/multipeer/syncActor.ts
+++ b/packages/sdk/src/adapters/multipeer/syncActor.ts
@@ -40,4 +40,5 @@ export type SyncActor = {
     activeInterpolations: Payloads.InterpolateActor[];
     behavior: BehaviorType;
     grabbedBy: string;
+    exclusiveToUser: string;
 };

--- a/packages/sdk/src/adapters/multipeer/syncActor.ts
+++ b/packages/sdk/src/adapters/multipeer/syncActor.ts
@@ -34,6 +34,7 @@ export type ActiveSoundInstance = {
  */
 export type SyncActor = {
     actorId: string;
+    exclusiveToUser: string;
     created: CreateActor;
     createdAnimations: CreateAnimation[];
     activeSoundInstances: ActiveSoundInstance[];

--- a/packages/sdk/src/adapters/multipeer/syncActor.ts
+++ b/packages/sdk/src/adapters/multipeer/syncActor.ts
@@ -34,7 +34,6 @@ export type ActiveSoundInstance = {
  */
 export type SyncActor = {
     actorId: string;
-    exclusiveToUser: string;
     created: CreateActor;
     createdAnimations: CreateAnimation[];
     activeSoundInstances: ActiveSoundInstance[];

--- a/packages/sdk/src/types/runtime/actor.ts
+++ b/packages/sdk/src/types/runtime/actor.ts
@@ -56,7 +56,7 @@ export interface ActorLike {
     parentId: string;
     name: string;
     tag: string;
-    exclusiveToUser: string | User;
+    exclusiveToUser: string;
     subscriptions: SubscriptionType[];
     transform: Partial<ActorTransformLike>;
     appearance: Partial<AppearanceLike>;
@@ -91,7 +91,7 @@ export class Actor implements ActorLike, Patchable<ActorLike> {
 
     private _name: string;
     private _tag: string;
-    private _exclusiveToUser: User;
+    private _exclusiveToUser: string;
     private _parentId = ZeroGuid;
     private _subscriptions: SubscriptionType[] = [];
     private _transform = new ActorTransform();
@@ -117,7 +117,9 @@ export class Actor implements ActorLike, Patchable<ActorLike> {
     public get name() { return this._name; }
     public get tag() { return this._tag; }
     public set tag(value) { this._tag = value; this.actorChanged('tag'); }
-    public get exclusiveToUser(): User { return this.parent && this.parent.exclusiveToUser || this._exclusiveToUser; }
+    public get exclusiveToUser(): string {
+        return this.parent && this.parent.exclusiveToUser || this._exclusiveToUser;
+    }
     public get subscriptions() { return this._subscriptions; }
     public get transform() { return this._transform; }
     public set transform(value) { this._transform.copy(value); }
@@ -690,10 +692,7 @@ export class Actor implements ActorLike, Patchable<ActorLike> {
         if (from.parentId) this._parentId = from.parentId;
         if (from.name) this._name = from.name;
         if (from.tag) this._tag = from.tag;
-        if (from.exclusiveToUser) {
-            this._exclusiveToUser = this.context.user(typeof from.exclusiveToUser === 'string' ?
-                from.exclusiveToUser : from.exclusiveToUser.id);
-        }
+        if (from.exclusiveToUser) this._exclusiveToUser = from.exclusiveToUser;
         if (from.transform) this._transform.copy(from.transform);
         if (from.attachment) this.attach(from.attachment.userId, from.attachment.attachPoint);
         if (from.appearance) this._appearance.copy(from.appearance);
@@ -714,7 +713,7 @@ export class Actor implements ActorLike, Patchable<ActorLike> {
             parentId: this._parentId,
             name: this._name,
             tag: this._tag,
-            exclusiveToUser: this.exclusiveToUser && this.exclusiveToUser.id || undefined,
+            exclusiveToUser: this._exclusiveToUser,
             transform: this._transform.toJSON(),
             appearance: this._appearance.toJSON(),
             attachment: this._attachment ? this._attachment.toJSON() : undefined,
@@ -735,9 +734,6 @@ export class Actor implements ActorLike, Patchable<ActorLike> {
     public static sanitize(msg: Partial<ActorLike>): Partial<ActorLike>;
     public static sanitize(msg: ActorLike | Partial<ActorLike>): ActorLike | Partial<ActorLike> {
         msg = resolveJsonValues(msg);
-        if (msg.exclusiveToUser && typeof msg.exclusiveToUser !== 'string') {
-            msg.exclusiveToUser = msg.exclusiveToUser.id;
-        }
         if (msg.appearance) {
             msg.appearance = Appearance.sanitize(msg.appearance);
         }

--- a/packages/sdk/src/types/runtime/actor.ts
+++ b/packages/sdk/src/types/runtime/actor.ts
@@ -91,7 +91,7 @@ export class Actor implements ActorLike, Patchable<ActorLike> {
 
     private _name: string;
     private _tag: string;
-    private _exclusiveToUser: string;
+    private _exclusiveToUser: User;
     private _parentId = ZeroGuid;
     private _subscriptions: SubscriptionType[] = [];
     private _transform = new ActorTransform();
@@ -117,7 +117,7 @@ export class Actor implements ActorLike, Patchable<ActorLike> {
     public get name() { return this._name; }
     public get tag() { return this._tag; }
     public set tag(value) { this._tag = value; this.actorChanged('tag'); }
-    public get exclusiveToUser() { return this._exclusiveToUser; }
+    public get exclusiveToUser(): User { return this.parent && this.parent.exclusiveToUser || this._exclusiveToUser; }
     public get subscriptions() { return this._subscriptions; }
     public get transform() { return this._transform; }
     public set transform(value) { this._transform.copy(value); }
@@ -686,7 +686,7 @@ export class Actor implements ActorLike, Patchable<ActorLike> {
         if (from.tag) this._tag = from.tag;
         if (from.exclusiveToUser) {
             this._exclusiveToUser = typeof from.exclusiveToUser === 'string' ?
-                from.exclusiveToUser : from.exclusiveToUser.id;
+                this.context.user(from.exclusiveToUser) : from.exclusiveToUser;
         }
         if (from.transform) this._transform.copy(from.transform);
         if (from.attachment) this.attach(from.attachment.userId, from.attachment.attachPoint);
@@ -729,6 +729,9 @@ export class Actor implements ActorLike, Patchable<ActorLike> {
     public static sanitize(msg: Partial<ActorLike>): Partial<ActorLike>;
     public static sanitize(msg: ActorLike | Partial<ActorLike>): ActorLike | Partial<ActorLike> {
         msg = resolveJsonValues(msg);
+        if (msg.exclusiveToUser && typeof msg.exclusiveToUser !== 'string') {
+            msg.exclusiveToUser = msg.exclusiveToUser.id;
+        }
         if (msg.appearance) {
             msg.appearance = Appearance.sanitize(msg.appearance);
         }

--- a/packages/sdk/src/types/runtime/actor.ts
+++ b/packages/sdk/src/types/runtime/actor.ts
@@ -56,6 +56,12 @@ export interface ActorLike {
     parentId: string;
     name: string;
     tag: string;
+
+    /**
+     * When supplied, this actor will be unsynchronized, and only exist on the client
+     * of the User with the given ID. This value can only be set at actor creation.
+     * Any actors parented to this actor will also be exclusive to the given user.
+     */
     exclusiveToUser: string;
     subscriptions: SubscriptionType[];
     transform: Partial<ActorTransformLike>;
@@ -117,6 +123,8 @@ export class Actor implements ActorLike, Patchable<ActorLike> {
     public get name() { return this._name; }
     public get tag() { return this._tag; }
     public set tag(value) { this._tag = value; this.actorChanged('tag'); }
+
+    /** @inheritdoc */
     public get exclusiveToUser(): string {
         return this.parent && this.parent.exclusiveToUser || this._exclusiveToUser;
     }

--- a/packages/sdk/src/types/runtime/actor.ts
+++ b/packages/sdk/src/types/runtime/actor.ts
@@ -56,7 +56,8 @@ export interface ActorLike {
     parentId: string;
     name: string;
     tag: string;
-    subscriptions?: SubscriptionType[];
+    exclusiveToUser: string | User;
+    subscriptions: SubscriptionType[];
     transform: Partial<ActorTransformLike>;
     appearance: Partial<AppearanceLike>;
     light: Partial<LightLike>;
@@ -80,20 +81,21 @@ export interface ActorSet {
  */
 export class Actor implements ActorLike, Patchable<ActorLike> {
     // tslint:disable:variable-name
-    private _internal: InternalActor;
+    private _internal = new InternalActor(this);
     /** @hidden */
     public get internal() { return this._internal; }
 
-    private _emitter: events.EventEmitter;
+    private _emitter = new events.EventEmitter();
     /** @hidden */
     public get emitter() { return this._emitter; }
 
     private _name: string;
     private _tag: string;
-    private _parentId: string;
+    private _exclusiveToUser: string;
+    private _parentId = ZeroGuid;
     private _subscriptions: SubscriptionType[] = [];
-    private _transform: ActorTransform;
-    private _appearance: Appearance;
+    private _transform = new ActorTransform();
+    private _appearance = new Appearance(this);
     private _light: Light;
     private _rigidBody: RigidBody;
     private _collider: Collider;
@@ -115,6 +117,7 @@ export class Actor implements ActorLike, Patchable<ActorLike> {
     public get name() { return this._name; }
     public get tag() { return this._tag; }
     public set tag(value) { this._tag = value; this.actorChanged('tag'); }
+    public get exclusiveToUser() { return this._exclusiveToUser; }
     public get subscriptions() { return this._subscriptions; }
     public get transform() { return this._transform; }
     public set transform(value) { this._transform.copy(value); }
@@ -149,12 +152,7 @@ export class Actor implements ActorLike, Patchable<ActorLike> {
 
     // tslint:disable-next-line:variable-name
     private constructor(private _context: Context, private _id: string) {
-        this._internal = new InternalActor(this);
-        this._emitter = new events.EventEmitter();
-        this._parentId = ZeroGuid;
-
         // Actor patching: Observe the transform for changed values.
-        this._transform = new ActorTransform();
         observe({
             target: this._transform,
             targetName: 'transform',
@@ -162,7 +160,6 @@ export class Actor implements ActorLike, Patchable<ActorLike> {
         });
 
         // Observe changes to the looks of this actor
-        this._appearance = new Appearance(this);
         observe({
             target: this._appearance,
             targetName: 'appearance',
@@ -687,6 +684,10 @@ export class Actor implements ActorLike, Patchable<ActorLike> {
         if (from.parentId) this._parentId = from.parentId;
         if (from.name) this._name = from.name;
         if (from.tag) this._tag = from.tag;
+        if (from.exclusiveToUser) {
+            this._exclusiveToUser = typeof from.exclusiveToUser === 'string' ?
+                from.exclusiveToUser : from.exclusiveToUser.id;
+        }
         if (from.transform) this._transform.copy(from.transform);
         if (from.attachment) this.attach(from.attachment.userId, from.attachment.attachPoint);
         if (from.appearance) this._appearance.copy(from.appearance);
@@ -707,6 +708,7 @@ export class Actor implements ActorLike, Patchable<ActorLike> {
             parentId: this._parentId,
             name: this._name,
             tag: this._tag,
+            exclusiveToUser: this._exclusiveToUser,
             transform: this._transform.toJSON(),
             appearance: this._appearance.toJSON(),
             attachment: this._attachment ? this._attachment.toJSON() : undefined,


### PR DESCRIPTION
* Add the `exclusiveToUser` field on actors
* Add the `userExclusiveMessages` field on clients as a message queue
* Add `shouldSendToUser` to Rule objects, which indicates whether a given payload should be sent to a given user
* Add the protocol preprocessor `ClientDesyncPreprocessor` (added to ClientSync and ClientExecution), which queues up messages related to user-exclusive actors in the client, then when a user joins that client, it re-sends the messages targeting that user and throws out the rest.

TODO: Write per-payload `shouldSendToUser` filters