### PR TITLE
Updated button event API for button vs click events

### DIFF
--- a/packages/functional-tests/src/app.ts
+++ b/packages/functional-tests/src/app.ts
@@ -253,7 +253,7 @@ export class App {
         this.exclusiveUserLabel = label.text;
 
         this.exclusiveUserToggle.setBehavior(MRE.ButtonBehavior)
-            .onClick('released', user => this.toggleExclusiveUser(user));
+            .onButton('released', user => this.toggleExclusiveUser(user));
 
         const floor = MRE.Actor.CreatePrimitive(this.context, {
             definition: {
@@ -365,7 +365,7 @@ export class App {
         }).value;
 
         this.playPauseButton.setBehavior(MRE.ButtonBehavior)
-            .onClick("released", user => {
+            .onButton("released", user => {
                 if (this.activeTest === null) {
                     this.runTest(user);
                 } else {
@@ -408,7 +408,7 @@ export class App {
         }).value;
 
         menuButton.setBehavior(MRE.ButtonBehavior)
-            .onClick("released", async () => {
+            .onButton("released", async () => {
                 await this.stopTest();
                 [this.contextLabel, this.playPauseButton, this.playPauseText]
                     = this.runnerActors

--- a/packages/functional-tests/src/menu.ts
+++ b/packages/functional-tests/src/menu.ts
@@ -4,8 +4,7 @@
  */
 
 import * as MRE from '@microsoft/mixed-reality-extension-sdk';
-
-import { App, BackgroundColor, FailureColor, NeutralColor, SuccessColor } from './app';
+import { App, FailureColor, NeutralColor, SuccessColor } from './app';
 import { TestFactory } from './test';
 import { Factories, FactoryMap } from './tests';
 import destroyActors from './utils/destroyActors';
@@ -90,7 +89,7 @@ export default class Menu {
 
             this.buttons[i].appearance.material = buttonMat;
             this.labels[i].text.contents = label;
-            behavior.onClick('released', handler);
+            behavior.onButton('released', handler);
         });
     }
 
@@ -190,7 +189,7 @@ export default class Menu {
         }).value;
 
         backButton.setBehavior(MRE.ButtonBehavior)
-            .onClick('released', () => {
+            .onButton('released', () => {
                 this.back();
                 this.show();
             });

--- a/packages/functional-tests/src/tests/altspacevr-video-test.ts
+++ b/packages/functional-tests/src/tests/altspacevr-video-test.ts
@@ -83,7 +83,7 @@ export default class AltspaceVRVideoTest extends Test {
         });
 
         const buttonBehavior = buttonPromise.value.setBehavior(MRE.ButtonBehavior);
-        buttonBehavior.onClick('released', cycleState);
+        buttonBehavior.onButton('released', cycleState);
 
         await this.stoppedAsync();
         return true;

--- a/packages/functional-tests/src/tests/asset-preload-test.ts
+++ b/packages/functional-tests/src/tests/asset-preload-test.ts
@@ -124,9 +124,9 @@ export default class AssetPreloadTest extends Test {
         });
 
         this.head.setBehavior(MRE.ButtonBehavior)
-            .onClick("pressed", () => this.cycleState());
+            .onButton("pressed", () => this.cycleState());
         this.sphere.setBehavior(MRE.ButtonBehavior)
-            .onClick("pressed", () => this.cycleState());
+            .onButton("pressed", () => this.cycleState());
     }
 
     private generateMaterial(): string {

--- a/packages/functional-tests/src/tests/grab-test.ts
+++ b/packages/functional-tests/src/tests/grab-test.ts
@@ -64,7 +64,7 @@ export default class GrabTest extends Test {
         // Set up cursor interaction. We add the input behavior ButtonBehavior to the cube.
         // Button behaviors have two pairs of events: hover start/stop, and click start/stop.
         const behavior = this.model.setBehavior(MRE.ButtonBehavior);
-        behavior.onClick('released', _ => {
+        behavior.onClick(_ => {
             this.state = 3;
             this.cycleState();
         });

--- a/packages/functional-tests/src/tests/input-test.ts
+++ b/packages/functional-tests/src/tests/input-test.ts
@@ -81,7 +81,7 @@ export default class InputTest extends Test {
             this.state = 1;
             this.cycleState();
         });
-        behavior.onClick('pressed', _ => {
+        behavior.onButton('pressed', _ => {
             this.state = 2;
             this.cycleState();
         });

--- a/packages/functional-tests/src/tests/sound-test.ts
+++ b/packages/functional-tests/src/tests/sound-test.ts
@@ -92,7 +92,7 @@ export default class SoundTest extends Test {
             }
             this._musicState = (this._musicState + 1) % 2;
         };
-        musicButtonBehavior.onClick('released', cycleMusicState);
+        musicButtonBehavior.onButton('released', cycleMusicState);
 
         const notesButtonPromise = MRE.Actor.CreatePrimitive(this.app.context, {
             definition: {
@@ -132,7 +132,7 @@ export default class SoundTest extends Test {
                 await delay(200);
             }
         };
-        notesButtonBehavior.onClick('released', playNotes);
+        notesButtonBehavior.onButton('released', playNotes);
 
         const dopplerButtonPromise = MRE.Actor.CreatePrimitive(this.app.context, {
             definition: {
@@ -203,7 +203,7 @@ export default class SoundTest extends Test {
             }
             this._dopplerSoundState = (this._dopplerSoundState + 1) % 2;
         };
-        dopplerButtonBehavior.onClick('released', cycleDopplerSoundState);
+        dopplerButtonBehavior.onButton('released', cycleDopplerSoundState);
 
         await this.stoppedAsync();
 

--- a/packages/functional-tests/src/tests/user-mask-test.ts
+++ b/packages/functional-tests/src/tests/user-mask-test.ts
@@ -100,9 +100,9 @@ export default class UserMaskTest extends Test {
         }, 750);
 
         // switch team on icon click
-        redIcon.setBehavior(MRE.ButtonBehavior).onClick('pressed',
+        redIcon.setBehavior(MRE.ButtonBehavior).onButton('pressed',
             user => this.switchTeams(user));
-        blueIcon.setBehavior(MRE.ButtonBehavior).onClick('pressed',
+        blueIcon.setBehavior(MRE.ButtonBehavior).onButton('pressed',
             user => this.switchTeams(user));
 
         await this.stoppedAsync();

--- a/packages/sdk/src/types/runtime/behaviors/buttonBehavior.ts
+++ b/packages/sdk/src/types/runtime/behaviors/buttonBehavior.ts
@@ -13,6 +13,7 @@ export class ButtonBehavior extends TargetBehavior {
     // tslint:disable:variable-name
     private _hover: DiscreteAction = new DiscreteAction();
     private _click: DiscreteAction = new DiscreteAction();
+    private _button: DiscreteAction = new DiscreteAction();
     // tslint:enable:variable-name
 
     /** @inheritdoc */
@@ -20,6 +21,7 @@ export class ButtonBehavior extends TargetBehavior {
 
     public get hover() { return this._hover; }
     public get click() { return this._click; }
+    public get button() { return this._button; }
 
     /**
      * Add a hover handler to be called when the given hover state is triggered.
@@ -35,13 +37,23 @@ export class ButtonBehavior extends TargetBehavior {
 
     /**
      * Add a click handler to be called when the given click state is triggered.
-     * @param clickState The click state to fire the handler on.
      * @param handler The handler to call when the click state is triggered.
      * @return This button behavior.
      */
-    public onClick(clickState: 'pressed' | 'released', handler: ActionHandler): this {
-        const actionState: ActionState = (clickState === 'pressed') ? 'started' : 'stopped';
-        this._click.on(actionState, handler);
+    public onClick(handler: ActionHandler): this {
+        this._click.on('started', handler);
+        return this;
+    }
+
+    /**
+     * Add a button handler to be called when a complete button click has occured.
+     * @param buttonState The button state to fire the handler on.
+     * @param handler The handler to call when the click state is triggered.
+     * @return This button behavior.
+     */
+    public onButton(buttonState: 'pressed' | 'released', handler: ActionHandler): this {
+        const actionState: ActionState = (buttonState === 'pressed') ? 'started' : 'stopped';
+        this._button.on(actionState, handler);
         return this;
     }
 


### PR DESCRIPTION
This will allow for the differentiation of these button events for long press grabs and clicks on 3dof and 2d within host apps where button conflicts happen for grab and button interactions.

NOTE: The previous click event that was pressed and released is now a higher level click event that only happens when a long press has not happened and been handled by a grab.  A new button event has been added for raising events in the app on a button pressed and released.