### PR TITLE
Make subscriptions only a part of the patch.

### DIFF
--- a/packages/sdk/src/adapters/multipeer/rules.ts
+++ b/packages/sdk/src/adapters/multipeer/rules.ts
@@ -992,41 +992,6 @@ export const Rules: { [id in Payloads.PayloadType]: Rule } = {
     },
 
     // ========================================================================
-    'update-subscriptions': {
-        ...DefaultRule,
-        synchronization: {
-            stage: 'create-actors',
-            before: 'ignore',
-            during: 'queue',
-            after: 'allow'
-        },
-        client: {
-            ...DefaultRule.client,
-            shouldSendToUser: (message: Message<Payloads.UpdateSubscriptions>, userId, session, client) => {
-                const exclusiveUser = session.actorSet[message.payload.id].exclusiveToUser;
-                return exclusiveUser ? exclusiveUser === userId : null;
-            }
-        },
-        session: {
-            ...DefaultRule.session,
-            beforeReceiveFromApp: (
-                session: Session,
-                message: Message<Payloads.UpdateSubscriptions>
-            ) => {
-                const syncActor = session.actorSet[message.payload.id];
-                if (syncActor) {
-                    syncActor.initialization.message.payload.actor.subscriptions =
-                        (syncActor.initialization.message.payload.actor.subscriptions || []).filter(
-                            subscription => message.payload.removes.indexOf(subscription) < 0);
-                    syncActor.initialization.message.payload.actor.subscriptions.push(
-                        ...message.payload.adds);
-                }
-                return message;
-            }
-        }
-    },
-
-    // ========================================================================
     'user-joined': {
         ...ClientOnlyRule,
         session: {

--- a/packages/sdk/src/types/internal/context.ts
+++ b/packages/sdk/src/types/internal/context.ts
@@ -82,12 +82,10 @@ export class InternalContext {
     }
 
     public CreateEmpty(options?: {
-        actor?: Partial<ActorLike>,
-        subscriptions?: SubscriptionType[]
+        actor?: Partial<ActorLike>
     }): ForwardPromise<Actor> {
         options = { ...options };
         options = {
-            subscriptions: [],
             ...options,
             actor: {
                 ...options.actor,
@@ -105,12 +103,10 @@ export class InternalContext {
         resourceUrl: string,
         assetName?: string,
         colliderType?: CreateColliderType,
-        actor?: Partial<ActorLike>,
-        subscriptions?: SubscriptionType[]
+        actor?: Partial<ActorLike>
     }): ForwardPromise<Actor> {
         options = { ...options };
         options = {
-            subscriptions: [],
             colliderType: 'none',
             ...options,
             actor: {
@@ -127,12 +123,10 @@ export class InternalContext {
 
     public CreateFromLibrary(options: {
         resourceId: string,
-        actor?: Partial<ActorLike>,
-        subscriptions?: SubscriptionType[]
+        actor?: Partial<ActorLike>
     }): ForwardPromise<Actor> {
         options = { ...options };
         options = {
-            subscriptions: [],
             ...options,
             actor: {
                 ...options.actor,
@@ -149,12 +143,10 @@ export class InternalContext {
     public CreatePrimitive(options: {
         definition: PrimitiveDefinition,
         addCollider?: boolean,
-        actor?: Partial<ActorLike>,
-        subscriptions?: SubscriptionType[]
+        actor?: Partial<ActorLike>
     }): ForwardPromise<Actor> {
         options = { ...options };
         options = {
-            subscriptions: [],
             addCollider: false,
             ...options,
             actor: {
@@ -171,12 +163,10 @@ export class InternalContext {
 
     public CreateFromPrefab(options: {
         prefabId: string,
-        actor?: Partial<ActorLike>,
-        subscriptions?: SubscriptionType[]
+        actor?: Partial<ActorLike>
     }): ForwardPromise<Actor> {
         options = { ...options };
         options = {
-            subscriptions: [],
             ...options,
             actor: {
                 ...options.actor,

--- a/packages/sdk/src/types/internal/context.ts
+++ b/packages/sdk/src/types/internal/context.ts
@@ -45,7 +45,6 @@ import {
     SetAnimationState,
     SetBehavior,
     SetSoundState,
-    UpdateSubscriptions,
     UserUpdate,
 } from '../network/payloads';
 
@@ -315,26 +314,6 @@ export class InternalContext {
                 curve,
                 enabled: true
             } as InterpolateActor);
-        }
-    }
-
-    public updateSubscriptions(
-        actorId: string,
-        options: {
-            adds?: SubscriptionType | SubscriptionType[],
-            removes?: SubscriptionType | SubscriptionType[]
-        }
-    ) {
-        const actor = this.actorSet[actorId];
-        if (actor) {
-            this.protocol.sendPayload({
-                type: 'update-subscriptions',
-                id: actorId,
-                adds: options.adds,
-                removes: options.removes
-            } as UpdateSubscriptions);
-        } else {
-            log.error('app', `Failed to update subscriptions. Actor ${actorId} not found.`);
         }
     }
 

--- a/packages/sdk/src/types/network/payloads/payloads.ts
+++ b/packages/sdk/src/types/network/payloads/payloads.ts
@@ -59,7 +59,6 @@ export type PayloadType
     | 'sync-request'
     | 'traces'
     | 'trigger-event-raised'
-    | 'update-subscriptions'
     | 'user-joined'
     | 'user-left'
     | 'user-update'
@@ -315,17 +314,6 @@ export type SetBehavior = Payload & {
     type: 'set-behavior';
     actorId: string;
     behaviorType: BehaviorType;
-};
-
-/**
- * @hidden
- * Update subscription flags on the actor
- */
-export type UpdateSubscriptions = Payload & {
-    type: 'update-subscriptions';
-    id: string;
-    adds: SubscriptionType[];
-    removes: SubscriptionType[];
 };
 
 /**

--- a/packages/sdk/src/types/network/payloads/payloads.ts
+++ b/packages/sdk/src/types/network/payloads/payloads.ts
@@ -166,7 +166,6 @@ export type EngineToAppRPC = Payload & {
  */
 export type CreateActorCommon = Payload & {
     actor: Partial<ActorLike>;
-    subscriptions: SubscriptionType[];
 };
 
 /**
@@ -210,7 +209,6 @@ export type CreatePrimitive = CreateActorCommon & {
     definition: PrimitiveDefinition;
     addCollider: boolean;
     actor: Partial<ActorLike>;
-    subscriptions: SubscriptionType[];
 };
 
 /**

--- a/packages/sdk/src/types/runtime/actor.ts
+++ b/packages/sdk/src/types/runtime/actor.ts
@@ -199,8 +199,7 @@ export class Actor implements ActorLike, Patchable<ActorLike> {
      * @param options.actor The initial state of the actor.
      */
     public static CreateEmpty(context: Context, options?: {
-        actor?: Partial<ActorLike>,
-        subscriptions?: SubscriptionType[]
+        actor?: Partial<ActorLike>
     }): ForwardPromise<Actor> {
         return context.internal.CreateEmpty(options);
     }
@@ -218,8 +217,7 @@ export class Actor implements ActorLike, Patchable<ActorLike> {
         resourceUrl: string,
         assetName?: string,
         colliderType?: CreateColliderType,
-        actor?: Partial<ActorLike>,
-        subscriptions?: SubscriptionType[]
+        actor?: Partial<ActorLike>
     }): ForwardPromise<Actor> {
         return context.internal.CreateFromGltf(options);
     }
@@ -232,8 +230,7 @@ export class Actor implements ActorLike, Patchable<ActorLike> {
         resourceUrl: string,
         assetName?: string,
         colliderType?: CreateColliderType,
-        actor?: Partial<ActorLike>,
-        subscriptions?: SubscriptionType[]
+        actor?: Partial<ActorLike>
     }): ForwardPromise<Actor> {
         return context.internal.CreateFromGltf(options);
     }
@@ -247,8 +244,7 @@ export class Actor implements ActorLike, Patchable<ActorLike> {
      */
     public static CreateFromLibrary(context: Context, options: {
         resourceId: string,
-        actor?: Partial<ActorLike>,
-        subscriptions?: SubscriptionType[]
+        actor?: Partial<ActorLike>
     }): ForwardPromise<Actor> {
         return context.internal.CreateFromLibrary(options);
     }
@@ -263,8 +259,7 @@ export class Actor implements ActorLike, Patchable<ActorLike> {
     public static CreatePrimitive(context: Context, options: {
         definition: PrimitiveDefinition,
         addCollider?: boolean,
-        actor?: Partial<ActorLike>,
-        subscriptions?: SubscriptionType[]
+        actor?: Partial<ActorLike>
     }): ForwardPromise<Actor> {
         return context.internal.CreatePrimitive(options);
     }
@@ -278,8 +273,7 @@ export class Actor implements ActorLike, Patchable<ActorLike> {
      */
     public static CreateFromPrefab(context: Context, options: {
         prefabId: string,
-        actor?: Partial<ActorLike>,
-        subscriptions?: SubscriptionType[]
+        actor?: Partial<ActorLike>
     }): ForwardPromise<Actor> {
         return context.internal.CreateFromPrefab(options);
     }
@@ -468,10 +462,8 @@ export class Actor implements ActorLike, Patchable<ActorLike> {
      * @param subscription The type of subscription to add.
      */
     public subscribe(subscription: SubscriptionType) {
-        return this.updateSubscriptions({
-            adds: [subscription],
-            removes: []
-        });
+        this._subscriptions.push(subscription);
+        this.actorChanged('subscriptions');
     }
 
     /**
@@ -479,21 +471,8 @@ export class Actor implements ActorLike, Patchable<ActorLike> {
      * @param subscription The type of subscription to remove.
      */
     public unsubscribe(subscription: SubscriptionType) {
-        return this.updateSubscriptions({
-            adds: [],
-            removes: [subscription]
-        });
-    }
-
-    private updateSubscriptions(options: {
-        adds?: SubscriptionType | SubscriptionType[],
-        removes?: SubscriptionType | SubscriptionType[]
-    }) {
-        const adds = options.adds ? Array.isArray(options.adds) ? options.adds : [options.adds] : [];
-        const removes = options.removes ? Array.isArray(options.removes) ? options.removes : [options.removes] : [];
-        this._subscriptions = this._subscriptions.filter(subscription => removes.indexOf(subscription) < 0);
-        this._subscriptions.push(...adds);
-        this.context.internal.updateSubscriptions(this.id, options);
+        this._subscriptions = this._subscriptions.filter(value => value !== subscription);
+        this.actorChanged('subscriptions');
     }
 
     /**


### PR DESCRIPTION
This is a cleanup associated with some redundancy in the subscriptions API as well as moving the subscription updates in to the actor patch.

This is referenced in issue #[318](https://github.com/microsoft/mixed-reality-extension-sdk/issues/318)