### PR TITLE
Grab lerping on synchronized clients

### DIFF
--- a/packages/functional-tests/src/server.ts
+++ b/packages/functional-tests/src/server.ts
@@ -15,8 +15,8 @@ process.on('uncaughtException', (err) => console.log('uncaughtException', err));
 process.on('unhandledRejection', (reason) => console.log('unhandledRejection', reason));
 
 MRE.log.enable('app');
-MRE.log.enable('network');
-MRE.log.enable('network-content');
+// MRE.log.enable('network');
+// MRE.log.enable('network-content');
 
 // Start listening for connections, and serve static files
 const server = new MRE.WebHost({

--- a/packages/functional-tests/src/server.ts
+++ b/packages/functional-tests/src/server.ts
@@ -15,8 +15,8 @@ process.on('uncaughtException', (err) => console.log('uncaughtException', err));
 process.on('unhandledRejection', (reason) => console.log('unhandledRejection', reason));
 
 MRE.log.enable('app');
-// MRE.log.enable('network');
-// MRE.log.enable('network-content');
+MRE.log.enable('network');
+MRE.log.enable('network-content');
 
 // Start listening for connections, and serve static files
 const server = new MRE.WebHost({

--- a/packages/sdk/src/adapters/multipeer/rules.ts
+++ b/packages/sdk/src/adapters/multipeer/rules.ts
@@ -279,6 +279,9 @@ export const Rules: { [id in Payloads.PayloadType]: Rule } = {
                             }
                         }
                     });
+
+                    // We have merged the actor correction in to an existing actor update.  We do not want to
+                    // propagate the correction message further.
                     return undefined;
                 }
                 return message;
@@ -357,6 +360,9 @@ export const Rules: { [id in Payloads.PayloadType]: Rule } = {
                 if (queuedMessage) {
                     const existingPayload = queuedMessage.message.payload as Partial<Payloads.ActorUpdate>;
                     existingPayload.actor = deepmerge(existingPayload.actor, payload.actor);
+
+                    // We have merged the actor update in to an existing actor update.  We do not want to
+                    // propagate the update message further.
                     return undefined;
                 }
                 return message;

--- a/packages/sdk/src/adapters/multipeer/rules.ts
+++ b/packages/sdk/src/adapters/multipeer/rules.ts
@@ -260,8 +260,9 @@ export const Rules: { [id in Payloads.PayloadType]: Rule } = {
                 message: Message<Payloads.ActorCorrection>,
                 promise: ExportedPromise
             ) => {
-                // Coalesce this update with the previously queued update if it exists, maintaining a single
-                // update for this actor rather than queuing a series of them.
+                // Coalesce this actor correction with the previously queued update if it exists, maintaining a single
+                // update for this actor rather than queuing a series of them.  This is fine, as we do not need to lerp
+                // an actor correction on a late join user.  It can just be the updated actor values.
                 const payload = message.payload;
                 const queuedMessage = client.queuedMessages
                     .filter(value =>

--- a/packages/sdk/src/types/network/payloads/payloads.ts
+++ b/packages/sdk/src/types/network/payloads/payloads.ts
@@ -7,10 +7,9 @@ import { OperationResultCode, Trace } from '..';
 import { CreateAnimationOptions, SetAnimationStateOptions } from '../../..';
 import { SetSoundStateOptions, SoundCommand } from '../../../sound';
 import { PrimitiveDefinition } from '../../primitiveTypes';
-import { ActorLike, ColliderType, UserLike } from '../../runtime';
+import { ActorLike, ColliderType, TransformLike, UserLike } from '../../runtime';
 import { ActionState, BehaviorType } from '../../runtime/behaviors';
 import { OperatingModel } from '../operatingModel';
-import { SubscriptionType } from '../subscriptionType';
 
 /**
  * @hidden
@@ -222,11 +221,21 @@ export type ObjectSpawned = Payload & {
 
 /**
  * @hidden
- * Bi-directional. Changed properties of an actor object (sparely populated).
+ * Bi-directional. Changed properties of an actor object (sparsely populated).
  */
 export type ActorUpdate = Payload & {
-    type: 'actor-update' | 'actor-correction';
+    type: 'actor-update';
     actor: Partial<ActorLike>;
+};
+
+/**
+ * @hidden
+ * Engine to app.  Actor correction that should be lerped on the other clients.
+ */
+export type ActorCorrection = Payload & {
+    type: 'actor-correction';
+    actorId: string;
+    appTransform: TransformLike;
 };
 
 /**


### PR DESCRIPTION
This adds in lerping for the synchronized clients during a grab.  This is performed through the existing actor correction payload that is no fully hooked up and supported.

Referenced by issue #[320](https://github.com/microsoft/mixed-reality-extension-sdk/issues/320)