### PR TITLE
Maintain app/local transform sync in multipeer session

### DIFF
--- a/packages/sdk/src/adapters/multipeer/rules.ts
+++ b/packages/sdk/src/adapters/multipeer/rules.ts
@@ -684,12 +684,12 @@ export const Rules: { [id in Payloads.PayloadType]: Rule } = {
                 // Check that this is the authoritative client
                 const exclusiveUser = session.actorSet[message.payload.actors[0].id].exclusiveToUser;
                 if (client.authoritative || client.userId && client.userId === exclusiveUser) {
-                    // Create local representations of the actors.
+                    // Create no-op creation message. Implicit sync from initialization until they're updated
                     for (const spawned of message.payload.actors) {
                         session.cacheInitializeActorMessage({
                             payload: {
                                 type: 'actor-update',
-                                actor: spawned
+                                actor: { id: spawned.id }
                             }
                         });
                     }

--- a/packages/sdk/src/adapters/multipeer/session.ts
+++ b/packages/sdk/src/adapters/multipeer/session.ts
@@ -257,6 +257,16 @@ export class Session extends EventEmitter {
             // Merge the update into the existing actor.
             syncActor.initialization.message.payload.actor
                 = deepmerge(syncActor.initialization.message.payload.actor, message.payload.actor);
+
+            // strip out transform data that wasn't updated
+            // so it doesn't desync from the updated one
+            const cacheTransform = syncActor.initialization.message.payload.actor.transform;
+            const patchTransform = message.payload.actor.transform;
+            if (patchTransform && !patchTransform.local) {
+                cacheTransform.local = undefined;
+            } else if (patchTransform && !patchTransform.app) {
+                cacheTransform.app = undefined;
+            }
         }
     }
 


### PR DESCRIPTION
* When it comes to glTFs and other implicitly created actors, don't overwrite the pristine load state with the patch's placeholders for the same state. This was assigning default materials and overwriting the client-only materials from the glTF.
* When caching transform updates in the session, only save one of app and local coordinates. Saving both requires recomputing after asymmetric updates, which is unnecessarily complicated.