### PR TITLE
Add test that "freezes" MREs

### DIFF
--- a/packages/functional-tests/src/tests/index.ts
+++ b/packages/functional-tests/src/tests/index.ts
@@ -18,6 +18,7 @@ import GltfGenTest from './gltf-gen-test';
 import GrabTest from './grab-test';
 import InputTest from './input-test';
 import InterpolationTest from './interpolation-test';
+import LibraryFailTest from './library-fail-test';
 import LightTest from './light-test';
 import LookAtTest from './look-at-test';
 import PhysicsSimTest from './physics-sim-test';
@@ -52,6 +53,7 @@ export const Factories = {
     'grab-test': (...args) => new GrabTest(...args),
     'input-test': (...args) => new InputTest(...args),
     'interpolation-test': (...args) => new InterpolationTest(...args),
+    'library-fail-test': (...args) => new LibraryFailTest(...args),
     'light-test': (...args) => new LightTest(...args),
     'look-at-test': (...args) => new LookAtTest(...args),
     'physics-sim-test': (...args) => new PhysicsSimTest(...args),

--- a/packages/functional-tests/src/tests/library-fail-test.ts
+++ b/packages/functional-tests/src/tests/library-fail-test.ts
@@ -1,0 +1,15 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import * as MRE from '@microsoft/mixed-reality-extension-sdk';
+import { Test } from '../test';
+
+export default class LibraryFailTest extends Test {
+    public expectedResultDescription = "Fails";
+
+    public async run(): Promise<boolean> {
+        await MRE.Actor.CreateFromLibrary(this.app.context, { resourceId: 'artifact:abdc' });
+        return true;
+    }
+}


### PR DESCRIPTION
Something about Unity-side exceptions kills the whole MRE update loop, even if they're caught.