### PR TITLE
Support for selective message timeouts

### DIFF
--- a/packages/sdk/src/adapters/multipeer/client.ts
+++ b/packages/sdk/src/adapters/multipeer/client.ts
@@ -19,6 +19,7 @@ import filterEmpty from '../../utils/filterEmpty';
 export type QueuedMessage = {
 	message: Message;
 	promise?: ExportedPromise;
+	timeoutSeconds?: number;
 };
 
 /**
@@ -125,7 +126,7 @@ export class Client extends EventEmitter {
 		}
 	}
 
-	public queueMessage(message: Message, promise?: ExportedPromise) {
+	public queueMessage(message: Message, promise?: ExportedPromise, timeoutSeconds?: number) {
 		const rule = Rules[message.payload.type] || MissingRule;
 		const beforeQueueMessageForClient = rule.client.beforeQueueMessageForClient || (() => message);
 		message = beforeQueueMessageForClient(this.session, this, message, promise);
@@ -133,7 +134,7 @@ export class Client extends EventEmitter {
 			// tslint:disable-next-line:max-line-length
 			log.verbose('network', `Client ${this.id.substr(0, 8)} queue id:${message.id.substr(0, 8)}, type:${message.payload.type}`);
 			log.verbose('network-content', JSON.stringify(message, (key, value) => filterEmpty(value)));
-			this.queuedMessages.push({ message, promise });
+			this.queuedMessages.push({ message, promise, timeoutSeconds });
 		}
 	}
 

--- a/packages/sdk/src/adapters/multipeer/protocols/clientHandshake.ts
+++ b/packages/sdk/src/adapters/multipeer/protocols/clientHandshake.ts
@@ -3,9 +3,12 @@
  * Licensed under the MIT License.
  */
 
+import { MissingRule, Rules } from '..';
 import { Client } from '../../..';
+import { Message } from '../../..';
 import { Handshake } from '../../../protocols/handshake';
 import { OperatingModel } from '../../../types/network/operatingModel';
+import { ExportedPromise } from '../../../utils/exportedPromise';
 
 /**
  * @hidden
@@ -16,5 +19,12 @@ export class ClientHandshake extends Handshake {
 
 	constructor(private client: Client, sessionId: string) {
 		super(client.conn, sessionId, OperatingModel.PeerAuthoritative);
+	}
+
+	/** @override */
+	public sendMessage(message: Message, promise?: ExportedPromise, timeoutSeconds?: number) {
+		// Apply timeout to messages going to the client.
+		const rule = Rules[message.payload.type] || MissingRule;
+		super.sendMessage(message, promise, rule.client.timeoutSeconds);
 	}
 }

--- a/packages/sdk/src/adapters/multipeer/protocols/clientStartup.ts
+++ b/packages/sdk/src/adapters/multipeer/protocols/clientStartup.ts
@@ -4,8 +4,11 @@
  */
 
 import { Client } from '..';
+import { MissingRule, Rules } from '..';
+import { Message } from '../../..';
 import * as Protocols from '../../../protocols';
 import * as Payloads from '../../../types/network/payloads';
+import { ExportedPromise } from '../../../utils/exportedPromise';
 
 export class ClientStartup extends Protocols.Protocol {
 	/** @override */
@@ -21,6 +24,13 @@ export class ClientStartup extends Protocols.Protocol {
 				await this.performStartup(syncRequest);
 			});
 		}
+	}
+
+	/** @override */
+	public sendMessage(message: Message, promise?: ExportedPromise, timeoutSeconds?: number) {
+		// Apply timeout to messages going to the client.
+		const rule = Rules[message.payload.type] || MissingRule;
+		super.sendMessage(message, promise, rule.client.timeoutSeconds);
 	}
 
 	/**

--- a/packages/sdk/src/adapters/multipeer/protocols/clientSync.ts
+++ b/packages/sdk/src/adapters/multipeer/protocols/clientSync.ts
@@ -59,17 +59,17 @@ export class ClientSync extends Protocols.Protocol {
 	 * @override
 	 * Handle the outgoing message according to the synchronization rules specified for this payload.
 	 */
-	public sendMessage(message: Message, promise?: ExportedPromise) {
+	public sendMessage(message: Message, promise?: ExportedPromise, timeoutSeconds?: number) {
 		message.id = message.id || UUID();
 		const handling = this.handlingForMessage(message);
 		// tslint:disable-next-line:switch-default
 		switch (handling) {
 			case 'allow': {
-				super.sendMessage(message, promise);
+				super.sendMessage(message, promise, timeoutSeconds);
 				break;
 			}
 			case 'queue': {
-				this.client.queueMessage(message, promise);
+				this.client.queueMessage(message, promise, timeoutSeconds);
 				break;
 			}
 			case 'ignore': {
@@ -327,7 +327,7 @@ export class ClientSync extends Protocols.Protocol {
 				break;
 			}
 			for (const queuedMessage of queuedMessages) {
-				this.sendMessage(queuedMessage.message, queuedMessage.promise);
+				this.sendMessage(queuedMessage.message, queuedMessage.promise, queuedMessage.timeoutSeconds);
 			}
 			await this.drainPromises();
 		} while (true);

--- a/packages/sdk/src/adapters/multipeer/rules.ts
+++ b/packages/sdk/src/adapters/multipeer/rules.ts
@@ -67,6 +67,12 @@ export type Rule = {
 	 */
 	client: {
 		/**
+		 * If non-zero, a timeout will be set for this message. If we don't receive a reply before the
+		 * timeout expires, the client connection will be closed. Only applicable to messages expecting
+		 * replies.
+		 */
+		timeoutSeconds: number;
+		/**
 		 * Called before a message is queued for later delivery to a client.
 		 * @param session The current session.
 		 * @param client The client to receive the message.
@@ -129,6 +135,7 @@ export const DefaultRule: Rule = {
 		after: 'allow'
 	},
 	client: {
+		timeoutSeconds: 0,
 		beforeQueueMessageForClient: (
 			session: Session, client: Client, message: any, promise: ExportedPromise) => {
 			return message;
@@ -585,7 +592,13 @@ export const Rules: { [id in Payloads.PayloadType]: Rule } = {
 	'engine2app-rpc': ClientOnlyRule,
 
 	// ========================================================================
-	'handshake': ClientOnlyRule,
+	'handshake': {
+		...ClientOnlyRule,
+		client: {
+			...ClientOnlyRule.client,
+			timeoutSeconds: 30
+		},
+	},
 
 	// ========================================================================
 	'handshake-complete': ClientOnlyRule,
@@ -610,6 +623,10 @@ export const Rules: { [id in Payloads.PayloadType]: Rule } = {
 			during: 'allow',
 			after: 'allow',
 		},
+		client: {
+			...DefaultRule.client,
+			timeoutSeconds: 30
+		}
 	},
 
 	// ========================================================================
@@ -1004,7 +1021,6 @@ export const Rules: { [id in Payloads.PayloadType]: Rule } = {
 				return message;
 			}
 		}
-
 	},
 
 	// ========================================================================
@@ -1015,6 +1031,10 @@ export const Rules: { [id in Payloads.PayloadType]: Rule } = {
 			before: 'error',
 			during: 'allow',
 			after: 'error'
+		},
+		client: {
+			...DefaultRule.client,
+			timeoutSeconds: 30
 		}
 	},
 


### PR DESCRIPTION
Timeouts are now set for these message types only:
- handshake
- heartbeat
- sync-animations (and this one will be going away soon)

Your MRE can now stack up 100s of load-gltf calls and it won't disconnect all your mobile users :)

Fixes #315