### PR TITLE
Soren/fix mediainstance timing

### DIFF
--- a/packages/functional-tests/src/tests/sound-test.ts
+++ b/packages/functional-tests/src/tests/sound-test.ts
@@ -82,9 +82,9 @@ export default class SoundTest extends Test {
 				looping: true,
 				doppler: 0.0,
 				spread: 0.7,
-				rolloffStartDistance: 2.5
-			},
-			0.0);
+				rolloffStartDistance: 2.5,
+				time: 30.0
+			});
 		musicSoundInstance.pause();
 		const musicButtonBehavior = musicButton.setBehavior(MRE.ButtonBehavior);
 		const cycleMusicState = () => {
@@ -190,8 +190,7 @@ export default class SoundTest extends Test {
 				doppler: 5.0,
 				spread: 0.3,
 				rolloffStartDistance: 9.3
-			},
-			0.0);
+			});
 		dopplerSoundInstance.pause();
 		const dopplerButtonBehavior = dopplerButton.setBehavior(MRE.ButtonBehavior);
 		const cycleDopplerSoundState = () => {

--- a/packages/functional-tests/src/tests/video-test.ts
+++ b/packages/functional-tests/src/tests/video-test.ts
@@ -56,8 +56,7 @@ export default class VideoTest extends Test {
 							looping: true,
 							spread: 0.7,
 							rolloffStartDistance: 2.5
-						},
-						0.0);
+						});
 					break;
 				case 1:
 					this.app.setOverrideText("Pausing!");
@@ -111,8 +110,7 @@ export default class VideoTest extends Test {
 							looping: true,
 							spread: 0.7,
 							rolloffStartDistance: 2.5
-						},
-						0.0);
+						});
 					break;
 				case 9:
 					this.app.setOverrideText("Stopping!");

--- a/packages/sdk/src/adapters/multipeer/protocols/clientSync.ts
+++ b/packages/sdk/src/adapters/multipeer/protocols/clientSync.ts
@@ -279,10 +279,11 @@ export class ClientSync extends Protocols.Protocol {
 					if (activeMediaInstance.message.payload.options.pitch !== undefined) {
 						timeOffset *= Math.pow(2.0, (activeMediaInstance.message.payload.options.pitch / 12.0));
 					}
-					if (activeMediaInstance.message.payload.startTimeOffset === undefined) {
-						activeMediaInstance.message.payload.startTimeOffset = 0.0;
+					if (activeMediaInstance.message.payload.options.time === undefined) {
+						activeMediaInstance.message.payload.options.time = 0.0;
 					}
-					activeMediaInstance.message.payload.startTimeOffset += timeOffset;
+					activeMediaInstance.message.payload.options.time += timeOffset;
+					activeMediaInstance.basisTime = targetTime;
 				}
 				return this.sendMessage(activeMediaInstance.message);
 			});

--- a/packages/sdk/src/adapters/multipeer/rules.ts
+++ b/packages/sdk/src/adapters/multipeer/rules.ts
@@ -992,31 +992,34 @@ export const Rules: { [id in Payloads.PayloadType]: Rule } = {
 
 						// store the updated sound instance if sound isn't stopping
 						if (message.payload.mediaCommand !== MediaCommand.Stop) {
-
-							// update startimeoffset and update basistime in oldmessage.
-							const targetTime = Date.now() / 1000.0;
-							if (activeMediaInstance.message.payload.options.paused !== true) {
-								let timeOffset = (targetTime - activeMediaInstance.basisTime);
-								if (activeMediaInstance.message.payload.options.pitch !== undefined) {
-									timeOffset *= Math.pow(2.0,
-										(activeMediaInstance.message.payload.options.pitch / 12.0));
+							// if speed or position changes, reset basistime and recalculate the time.
+							if (message.payload.options.time !== undefined) {
+								// a time change(seek) just needs to reset basis time. The payload merge does the rest
+								activeMediaInstance.basisTime = basisTime;
+							} else if (message.payload.options.paused !== undefined ||
+								message.payload.options.pitch !== undefined) {
+								// if the media instance wasn't paused, then recalculate the current time
+								// if media instance was paused then current time doesn't change
+								if (activeMediaInstance.message.payload.options.paused !== true) {
+									if (activeMediaInstance.message.payload.options.time === undefined) {
+										activeMediaInstance.message.payload.options.time = 0.0;
+									}
+									let timeOffset = (targetTime - activeMediaInstance.basisTime);
+									if (activeMediaInstance.message.payload.options.pitch !== undefined) {
+										timeOffset *= Math.pow(2.0,
+											(activeMediaInstance.message.payload.options.pitch / 12.0));
+									}
+									activeMediaInstance.message.payload.options.time += timeOffset;
 								}
-								if (activeMediaInstance.message.payload.startTimeOffset === undefined) {
-									activeMediaInstance.message.payload.startTimeOffset = 0.0;
-								}
-								activeMediaInstance.message.payload.startTimeOffset += timeOffset;
+								activeMediaInstance.basisTime = basisTime;
 							}
 
-							if (activeMediaInstance.message.payload.options.time !== undefined) {
-								activeMediaInstance.message.payload.startTimeOffset = activeMediaInstance.message.payload.options.time;
-							}
-
-							// merge existing message and new message
+							// merge existing payload and new payload
 							activeMediaInstance.message.payload.options = {
 								...activeMediaInstance.message.payload.options,
 								...message.payload.options
 							};
-							syncActor.activeMediaInstances.push({ message: activeMediaInstance.message, basisTime });
+							syncActor.activeMediaInstances.push(activeMediaInstance);
 						}
 					}
 

--- a/packages/sdk/src/types/internal/context.ts
+++ b/packages/sdk/src/types/internal/context.ts
@@ -284,7 +284,6 @@ export class InternalContext {
 		command: MediaCommand,
 		options?: SetMediaStateOptions,
 		mediaAssetId?: string,
-		startTimeOffset?: number
 	) {
 		this.protocol.sendPayload({
 			type: 'set-media-state',
@@ -292,8 +291,7 @@ export class InternalContext {
 			actorId: mediaInstance.actor.id,
 			mediaAssetId,
 			mediaCommand: command,
-			options,
-			startTimeOffset
+			options
 		} as SetMediaState);
 	}
 

--- a/packages/sdk/src/types/network/payloads/payloads.ts
+++ b/packages/sdk/src/types/network/payloads/payloads.ts
@@ -360,9 +360,9 @@ export type SetMediaState = Payload & {
 	id: string;
 	actorId: string;
 	mediaAssetId: string;
-	mediaCommand: MediaCommand,
-	options: SetMediaStateOptions,
-	startTimeOffset: number;
+	mediaCommand: MediaCommand;
+	options: SetMediaStateOptions;
+
 };
 
 /**

--- a/packages/sdk/src/types/runtime/actor.ts
+++ b/packages/sdk/src/types/runtime/actor.ts
@@ -522,28 +522,24 @@ export class Actor implements ActorLike, Patchable<ActorLike> {
 	 * Starts playing a preloaded sound.
 	 * @param soundAssetId Name of sound asset preloaded using AssetManager.
 	 * @param options Adjustments to pitch and volume, and other characteristics.
-	 * @param startTimeOffset How many seconds to offset into the sound
 	 */
 	public startSound(
 		soundAssetId: string,
 		options: SetAudioStateOptions,
-		startTimeOffset?: number
 	): MediaInstance {
-		return new MediaInstance(this, soundAssetId).start(options, startTimeOffset);
+		return new MediaInstance(this, soundAssetId).start(options);
 	}
 
 	/**
 	 * Starts playing a preloaded video stream.
 	 * @param videoStreamAssetId Name of video stream asset preloaded using AssetManager.
 	 * @param options Adjustments to pitch and volume, and other characteristics.
-	 * @param startTimeOffset How many seconds to offset into the sound
 	 */
 	public startVideoStream(
 		videoStreamAssetId: string,
 		options: SetVideoStateOptions,
-		startTimeOffset?: number
 	): MediaInstance {
-		return new MediaInstance(this, videoStreamAssetId).start(options, startTimeOffset);
+		return new MediaInstance(this, videoStreamAssetId).start(options);
 	}
 
 	/**

--- a/packages/sdk/src/types/runtime/mediaInstance.ts
+++ b/packages/sdk/src/types/runtime/mediaInstance.ts
@@ -27,10 +27,10 @@ export class MediaInstance {
 	/**
 	 * @hidden
 	 */
-	public start(options: SetMediaStateOptions, startTimeOffset?: number): MediaInstance {
+	public start(options: SetMediaStateOptions): MediaInstance {
 		this.actor.context.internal.lookupAsset(this.mediaAssetId).created.then(() => {
 			this.actor.context.internal.setMediaState(
-				this, MediaCommand.Start, options, this.mediaAssetId, startTimeOffset);
+				this, MediaCommand.Start, options, this.mediaAssetId);
 		}).catch(reason => {
 			log.error('app', `Start failed ${this.actor.id}. ${(reason || '').toString()}`.trim());
 		});


### PR DESCRIPTION
This removes an unnecessary parameter (startTimeOffset - not needed when we have a time variable in setmediastateoptions), repairs the time calculation on join-in-progress (was broken if using seek, and if doing more than one join-in-progress).