### PR TITLE
moved client traces into a separate logging facility

### DIFF
--- a/packages/functional-tests/src/server.ts
+++ b/packages/functional-tests/src/server.ts
@@ -14,8 +14,6 @@ dotenv.config();
 process.on('uncaughtException', (err) => console.log('uncaughtException', err));
 process.on('unhandledRejection', (reason) => console.log('unhandledRejection', reason));
 
-MRE.log.enable('app');
-MRE.log.enable('client-trace');
 // MRE.log.enable('network');
 // MRE.log.enable('network-content');
 

--- a/packages/functional-tests/src/server.ts
+++ b/packages/functional-tests/src/server.ts
@@ -15,6 +15,7 @@ process.on('uncaughtException', (err) => console.log('uncaughtException', err));
 process.on('unhandledRejection', (reason) => console.log('unhandledRejection', reason));
 
 MRE.log.enable('app');
+MRE.log.enable('client-trace');
 // MRE.log.enable('network');
 // MRE.log.enable('network-content');
 

--- a/packages/sdk/src/log.ts
+++ b/packages/sdk/src/log.ts
@@ -108,6 +108,7 @@ class Log {
 
 	private checkInitialize = () => {
 		this.enable('app');
+		this.enable('client');
 		const logging = process.env.MRE_LOGGING || '';
 		if (logging && logging.length) {
 			const parts = logging.split(',').map(s => s.trim());

--- a/packages/sdk/src/protocols/execution.ts
+++ b/packages/sdk/src/protocols/execution.ts
@@ -79,7 +79,7 @@ export class Execution extends Protocol {
 	/** @private */
 	public 'recv-traces' = (payload: Traces) => {
 		payload.traces.forEach(trace => {
-			log.log('client-trace', trace.severity, trace.message);
+			log.log('client', trace.severity, trace.message);
 		});
 	}
 

--- a/packages/sdk/src/protocols/execution.ts
+++ b/packages/sdk/src/protocols/execution.ts
@@ -79,7 +79,7 @@ export class Execution extends Protocol {
 	/** @private */
 	public 'recv-traces' = (payload: Traces) => {
 		payload.traces.forEach(trace => {
-			log.log('network', trace.severity, trace.message);
+			log.log('client-trace', trace.severity, trace.message);
 		});
 	}
 


### PR DESCRIPTION
Instead of client library traces going into the "network" category, they have their own category, and are enabled by default in functional tests. This is part of #24 , and builds on the logging PR on the unity repo.