### PR TITLE
Soren/cleanup expired sounds

### DIFF
--- a/packages/sdk/src/adapters/multipeer/protocols/clientSync.ts
+++ b/packages/sdk/src/adapters/multipeer/protocols/clientSync.ts
@@ -274,6 +274,11 @@ export class ClientSync extends Protocols.Protocol {
 				// TODO This sound tweaking should ideally be done on the client, because then it can consider the
 				// time it takes for packet to arrive. This is needed for optimal timing .
 				const targetTime = Date.now() / 1000.0;
+				if (activeMediaInstance.expirationTime !== undefined &&
+					targetTime > activeMediaInstance.expirationTime) {
+					// non-looping mediainstance has completed, so ignore it
+					return undefined;
+				}
 				if (activeMediaInstance.message.payload.options.paused !== true) {
 					let timeOffset = (targetTime - activeMediaInstance.basisTime);
 					if (activeMediaInstance.message.payload.options.pitch !== undefined) {

--- a/packages/sdk/src/adapters/multipeer/session.ts
+++ b/packages/sdk/src/adapters/multipeer/session.ts
@@ -286,8 +286,8 @@ export class Session extends EventEmitter {
 		this.assetCreatorSet[message.id] = message;
 	}
 
-	public cacheAssetCreation(assetId: string, creatorId: string) {
-		const syncAsset = this.assetSet[assetId] = { id: assetId } as Partial<SyncAsset>;
+	public cacheAssetCreation(assetId: string, creatorId: string, duration?: number) {
+		const syncAsset = this.assetSet[assetId] = { id: assetId, duration } as Partial<SyncAsset>;
 		const creator = this.assetCreatorSet[creatorId];
 		syncAsset.creatorMessageId = creatorId;
 

--- a/packages/sdk/src/adapters/multipeer/syncActor.ts
+++ b/packages/sdk/src/adapters/multipeer/syncActor.ts
@@ -30,6 +30,7 @@ export type CreateAnimation = {
 export type ActiveMediaInstance = {
 	message: Message<Payloads.SetMediaState>;
 	basisTime: number
+	expirationTime: number
 };
 
 /**

--- a/packages/sdk/src/adapters/multipeer/syncAsset.ts
+++ b/packages/sdk/src/adapters/multipeer/syncAsset.ts
@@ -12,4 +12,6 @@ export class SyncAsset {
 	public creatorMessageId: string;
 	/** Used only with batch creation, as definition is updated for other */
 	public update: Message<Payloads.AssetUpdate>;
+	/** Used only for runtime instances (like MediaInstances) that need to know the duration of the asset */
+	public duration?: number;
 }


### PR DESCRIPTION
Fixes the most important parts of #239 - garbage collect mediainstances for an actor whenever the actor tries to add a new mediainstance. And aggressively filtering out before clientsyncing.
And they are all destroyed when the actor is destroyed, too

This does not fix the case where an asset is destroyed - we ought to send a Stop command then, but it's much less important
