### PR TITLE
Retarget forwarded-for dependency to NPM

### DIFF
--- a/packages/sdk/package-lock.json
+++ b/packages/sdk/package-lock.json
@@ -460,8 +460,9 @@
       "integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg=="
     },
     "forwarded-for": {
-      "version": "github:stevenvergenz/forwarded-for#7296bec25d6fb79cbcae9b0061a5dccfc1bb2c76",
-      "from": "github:stevenvergenz/forwarded-for#7296bec"
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/forwarded-for/-/forwarded-for-1.1.0.tgz",
+      "integrity": "sha512-1Yam9ht7GyMXMBvuwJfUYqpdtLVodtT5ee5JMBzGiSwVVeh37ZN8LuOWkNHd6ho2zUxpSZCHuQrt1Vjl2AxDNA=="
     },
     "fs-extra": {
       "version": "7.0.1",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -49,7 +49,7 @@
     "@types/node": "^10.3.1",
     "debug": "^4.1.0",
     "deepmerge": "^2.1.1",
-    "forwarded-for": "github:stevenvergenz/forwarded-for#7296bec",
+    "forwarded-for": "^1.1.0",
     "query-string": "^6.2.0",
     "restify": "^7.2.0",
     "semver": "^5.6.0",


### PR DESCRIPTION
v0.12.2 included updating to a fork of an upstream dependency. That fork has been merged back into upstream, so this PR retargets package.json to the upstream NPM repo instead of GitHub.