### PR TITLE
Move ball counter label

### DIFF
--- a/packages/functional-tests/src/tests/physics-sim-test.ts
+++ b/packages/functional-tests/src/tests/physics-sim-test.ts
@@ -54,7 +54,7 @@ export default class PhysicsSimTest extends Test {
 			actor: {
 				parentId: root.id,
 				transform: {
-					app: { position: { x: -width / 2, y: height + 0.2, z: 0.1 } }
+					app: { position: { x: -width / 2, y: height + 0.2, z: 0.01 } }
 				},
 				text: {
 					contents: `Ball count: ${this.ballCount}`,


### PR DESCRIPTION
Fix #436 

The label was sunk into the back plate somehow. Confusing, given that my PR didn't change that transform value.