### PR TITLE
WebHost: add API for custom connection handlers

### DIFF
--- a/packages/sdk/src/adapters/multipeer/adapter.ts
+++ b/packages/sdk/src/adapters/multipeer/adapter.ts
@@ -43,7 +43,7 @@ export type MultipeerAdapterOptions = {
 export class MultipeerAdapter extends Adapter {
 
 	/** @inheritdoc */
-	public get name(): string { return this. constructor.name; }
+	public get name(): string { return this.constructor.name; }
 
 	// FUTURE: Make these child processes?
 	private sessions: { [id: string]: Session } = {};

--- a/packages/sdk/src/adapters/websocket/adapter.ts
+++ b/packages/sdk/src/adapters/websocket/adapter.ts
@@ -5,22 +5,15 @@
 
 import * as http from 'http';
 import QueryString from 'query-string';
-import * as Restify from 'restify';
 import UUID from 'uuid/v4';
 import * as WS from 'ws';
-import { Adapter, AdapterOptions } from '..';
+import { Adapter } from '..';
 import { Context, WebSocket } from '../..';
 import * as Constants from '../../constants';
-import verifyClient from '../../utils/verifyClient';
 import { log } from './../../log';
 
 // tslint:disable-next-line:no-var-requires
 const forwarded = require('forwarded-for');
-
-/**
- * WebSocket Adapter options.
- */
-export type WebSocketAdapterOptions = AdapterOptions;
 
 /**
  * The `WebSocketAdapter` is appropriate to use when the host environment has an authoritative simluation, and that
@@ -31,69 +24,40 @@ export type WebSocketAdapterOptions = AdapterOptions;
  *  - Server-based multiuser topologies
  */
 export class WebSocketAdapter extends Adapter {
-	/**
-	 * Creates a new instance of the WebSocket Adapter.
-	 */
-	constructor(options?: WebSocketAdapterOptions) {
-		super(options);
-	}
 
-	/**
-	 * Start the adapter listening for new connections.
-	 * @param onNewConnection Handler for new connections.
-	 */
-	public listen() {
-		if (!this.server) {
-			// If necessary, create a new web server.
-			return new Promise<Restify.Server>((resolve) => {
-				const server = this.server = Restify.createServer({ name: "WebSocket Adapter" });
-				this.server.listen(this.port, () => {
-					this.startListening();
-					resolve(server);
-				});
-			});
-		} else {
-			// Already have a server, so just start listening.
-			this.startListening();
-			return Promise.resolve(this.server);
-		}
-	}
+	/** @inheritdoc */
+	public get name(): string { return this. constructor.name; }
 
-	private startListening() {
-		// Create a server for upgrading HTTP connections to WebSockets.
-		const wss = new WS.Server({ server: this.server, verifyClient });
+	/** @inheritdoc */
+	public connectionRequest(ws: WS, request: http.IncomingMessage) {
+		log.info('network', "New WebSocket connection");
 
-		// Handle connection upgrades
-		wss.on('connection', (ws: WS, request: http.IncomingMessage) => {
-			log.info('network', "New WebSocket connection");
+		// Read the sessionId header.
+		let sessionId = request.headers[Constants.HTTPHeaders.SessionID] as string || UUID();
+		sessionId = decodeURIComponent(sessionId);
 
-			// Read the sessionId header.
-			let sessionId = request.headers[Constants.HTTPHeaders.SessionID] as string || UUID();
-			sessionId = decodeURIComponent(sessionId);
+		// Parse URL parameters.
+		const params = QueryString.parseUrl(request.url).query;
 
-			// Parse URL parameters.
-			const params = QueryString.parseUrl(request.url).query;
+		// Get the client's IP address rather than the last proxy connecting to you.
+		const address = forwarded(request, request.headers);
 
-			// Get the client's IP address rather than the last proxy connecting to you.
-			const address = forwarded(request, request.headers);
+		// Create a WebSocket for the connection.
+		const connection = new WebSocket(ws, address.ip);
 
-			// Create a WebSocket for the connection.
-			const connection = new WebSocket(ws, address.ip);
-
-			// Create a new context for the connection.
-			const context = new Context({
-				sessionId,
-				connection
-			});
-
-			// Start the context listening to network traffic.
-			context.internal.startListening().catch(() => connection.close());
-
-			// Pass the new context to the app
-			this.emitter.emit('connection', context, params);
-
-			// Start context's update loop.
-			context.internal.start();
+		// Create a new context for the connection.
+		const context = new Context({
+			sessionId,
+			connection
 		});
+
+		// Start the context listening to network traffic.
+		context.internal.startListening().catch(() => connection.close());
+
+		// Pass the new context to the app
+		this.emit('connection', context, params);
+
+		// Start context's update loop.
+		context.internal.start();
 	}
 }

--- a/packages/sdk/src/adapters/websocket/adapter.ts
+++ b/packages/sdk/src/adapters/websocket/adapter.ts
@@ -26,7 +26,7 @@ const forwarded = require('forwarded-for');
 export class WebSocketAdapter extends Adapter {
 
 	/** @inheritdoc */
-	public get name(): string { return this. constructor.name; }
+	public get name(): string { return this.constructor.name; }
 
 	/** @inheritdoc */
 	public connectionRequest(ws: WS, request: http.IncomingMessage) {

--- a/packages/sdk/src/webHost.ts
+++ b/packages/sdk/src/webHost.ts
@@ -3,82 +3,148 @@
  * Licensed under the MIT License.
  */
 
+import * as http from 'http';
+import QueryString from 'query-string';
 import * as Restify from 'restify';
+import { resolve as urlResolve } from 'url';
+import * as WS from 'ws';
 import { Adapter, MultipeerAdapter } from '.';
 import { log } from './log';
+import verifyClient from './utils/verifyClient';
 
-import { resolve as urlResolve } from 'url';
+export type WebSocketUpgradeRequestHandler = (ws: WS, request: http.IncomingMessage) => void;
+export type WebSocketRoute = string | RegExp;
 
 const BUFFER_KEYWORD = 'buffers';
+const BUFFER_REGEX = new RegExp(`^/${BUFFER_KEYWORD}/(.+)$`);
+
+/**
+ * Configuration options for a WebHost instance.
+ */
+export type WebHostOptions = {
+	/**
+	 * @member baseDir (Optional) The local folder where this app is running. Will attempt to read from BASE_DIR
+	 * environment variable.
+	 */
+	baseDir?: string;
+	/**
+	 * @member baseUrl (Optional) The public URL where this app is running. Will attempt to read from BASE_URL
+	 * environment variable. Will default to the IP address of the bound listening socket.
+	 */
+	baseUrl?: string;
+	/**
+	 * @member port (Optional) When options.server is not supplied and an internal web server is to be
+	 * created, this is the port number it should listen on. If this value is not given, it will attempt to read the
+	 * PORT environment variable, then default to 3901.
+	 */
+	port?: string | number;
+	/**
+	 * @member mreRoute (Optional) The URL path segment where your MRE is mounted to the WebSocket. Default
+	 * is the root (no path segment. Example: "/mre". Use this when you wish to mount additional WebSocket endpoints.
+	 * Default is "/".
+	 */
+	mreRoute?: string;
+	/**
+	 * @member adapter (Optional) MRE Adapter to register. Default is `MultpeerAdapter`. Pass `null` if you don't want
+	 * an adapter to be created.
+	 */
+	adapter?: Adapter;
+};
 
 /**
  * Sets up an HTTP server, and generates an MRE context for your app to use.
  */
 export class WebHost {
-	// tslint:disable:variable-name
-	private _adapter: Adapter;
-	private _baseDir: string;
-	private _baseUrl: string;
-	// tslint:enable:variable-name
-
-	public get adapter() { return this._adapter; }
-	public get baseDir() { return this._baseDir; }
-	public get baseUrl() { return this._baseUrl; }
-
+	// tslint:disable: variable-name
+	private _server: Restify.Server;
+	private wss: WS.Server;
 	private bufferMap: { [path: string]: Buffer } = {};
+	private webSocketRouteMap = new Map<WebSocketRoute, WebSocketUpgradeRequestHandler>();
+	// tslint:enable: variable-name
 
-	public constructor(
-		options: { baseDir?: string, baseUrl?: string, port?: string | number } = {}
-	) {
+	public get server() { return this._server; }
+	public get adapter() { return this.options.adapter; }
+	public get baseDir() { return this.options.baseDir; }
+	public get baseUrl() { return this.options.baseUrl; }
+
+	public constructor(private options?: WebHostOptions) {
 		const pjson = require('../package.json');
 		log.info('app', `Node: ${process.version}`);
 		log.info('app', `${pjson.name}: v${pjson.version}`);
 
-		this._baseDir = options.baseDir || process.env.BASE_DIR;
-		this._baseUrl = options.baseUrl || process.env.BASE_URL;
+		this.options = {
+			baseDir: process.env.BASE_DIR,
+			baseUrl: process.env.BASE_URL,
+			port: process.env.PORT || process.env.port || 3901,
+			mreRoute: '/',
+			...this.options
+		};
 
-		// Azure defines WEBSITE_HOSTNAME.
-		if (!this._baseUrl && process.env.WEBSITE_HOSTNAME) {
-			this._baseUrl = `https://${process.env.WEBSITE_HOSTNAME}`;
+		// Azure defines WEBSITE_HOSTNAME
+		if (!this.options.baseUrl && process.env.WEBSITE_HOSTNAME) {
+			this.options.baseUrl = `https://${process.env.WEBSITE_HOSTNAME}`;
 		}
 
-		// Resolve the port number. Heroku defines a PORT environment var (remapped from 80).
-		const port = options.port || process.env.PORT || 3901;
+		// Set the default adapter only if `adapter` was entirely omitted from `options`.
+		// If the caller passed `null` interpret this as "I don't want an adapter added".
+		if (this.options.adapter === undefined) {
+			this.options.adapter = new MultipeerAdapter();
+		}
 
-		// Create a Multi-peer adapter
-		this._adapter = new MultipeerAdapter({ port });
+		// If an adapter was provided, register it.
+		if (this.options.adapter) {
+			this.addAdapter(this.options.mreRoute, this.adapter);
+		}
 
-		// Start listening for new app connections from a multi-peer client.
-		this._adapter.listen()
-			.then(server => {
-				this._baseUrl = this._baseUrl || server.url.replace(/\[::\]/, '127.0.0.1');
-				log.info('app', `${server.name} listening on ${JSON.stringify(server.address())}`);
-				log.info('app', `baseUrl: ${this.baseUrl}`);
-				log.info('app', `baseDir: ${this.baseDir}`);
-				if (!!this.baseDir) {
-					this.serveStaticFiles(server);
-				}
-			})
-			.catch(reason => log.error('app', `Failed to start HTTP server: ${reason}`));
-	}
-
-	private serveStaticFiles(server: Restify.Server) {
-		server.get('/*',
-			// host static binaries
-			(req, res, next) => this.serveStaticBuffers(req, res, next),
-			// host static files
-			Restify.plugins.serveStatic({
-				directory: this._baseDir,
-				default: 'index.html'
+		// Start the web server, enable WebSockets, start serving static files, and start handling WebSocket connections.
+		this._server = Restify.createServer({ name: this.constructor.name });
+		this.wss = new WS.Server({ server: this.server });
+		this.server.listen(this.options.port, () => {
+			this.options.baseUrl = this.options.baseUrl || this.server.url.replace(/\[::\]/, '127.0.0.1');
+			log.info('app', `${this.server.name} listening on ${JSON.stringify(this.server.address())}`);
+			log.info('app', `baseUrl: ${this.baseUrl}`);
+			log.info('app', `baseDir: ${this.baseDir}`);
+			if (!!this.baseDir) {
+				serveStaticFiles();
 			}
-			));
-	}
+			handleWebSocketUpgrades();
+		});
 
-	private readonly bufferRegex = new RegExp(`^/${BUFFER_KEYWORD}/(.+)$`);
+		const serveStaticFiles = () => {
+			this.server.get('/*',
+				// host static binaries
+				(req, res, next) => this.serveStaticBuffers(req, res, next),
+				// host static files
+				Restify.plugins.serveStatic({
+					directory: this.options.baseDir,
+					default: 'index.html'
+				}));
+		};
+
+		const handleWebSocketUpgrades = () => {
+			this.wss.on('connection', (ws: WS, request: http.IncomingMessage) => {
+				const url = QueryString.parseUrl(request.url);
+				log.info('app', `New WebSocket connection on route ${url.url}`);
+				for (const pair of this.webSocketRouteMap) {
+					const [route, handler] = pair;
+					if (route instanceof RegExp) {
+						if (route.test(url.url)) {
+							handler(ws, request);
+							return;
+						}
+					} else if (route === url.url) {
+						handler(ws, request);
+						return;
+					}
+				}
+				ws.close(1000, "No handler registered for this route.");
+			});
+		};
+	}
 
 	private serveStaticBuffers(req: Restify.Request, res: Restify.Response, next: Restify.Next) {
 		// grab path part of URL
-		const matches = this.bufferRegex.exec(req.url);
+		const matches = BUFFER_REGEX.exec(req.url);
 		const procPath = matches && matches[1] || null;
 
 		// see if there's a handler registered for it
@@ -99,6 +165,39 @@ export class WebHost {
 	 */
 	public registerStaticBuffer(filename: string, blob: Buffer): string {
 		this.bufferMap[filename] = blob;
-		return urlResolve(this._baseUrl, `${BUFFER_KEYWORD}/${filename}`);
+		return urlResolve(this.options.baseUrl, `${BUFFER_KEYWORD}/${filename}`);
+	}
+
+	/**
+	 * Register a web socket connection handler for the given url route.
+	 * @param route string or RegExp of the route to match against.
+	 * @param handler The method to call when a new WebSocket connection is made with the matching route.
+	 */
+	public addWebSocketRoute(route: WebSocketRoute, handler: WebSocketUpgradeRequestHandler) {
+		if (!!handler) {
+			this.webSocketRouteMap.set(route, handler);
+		} else {
+			this.webSocketRouteMap.delete(route);
+		}
+	}
+
+	/**
+	 * Register an MRE adapter with this WebHost at the provided route.
+	 * @param route The route at which to mount the MRE adapter.
+	 * @param adapter The adapter to add.
+	 */
+	public addAdapter(route: WebSocketRoute, adapter: Adapter) {
+		if (adapter) {
+			log.info('app', `Added ${adapter.name} at route ${route}`);
+			this.addWebSocketRoute(route, (ws, request) => {
+				if (!verifyClient(request)) {
+					ws.close(1000, "Unsupported MRE version.");
+					return;
+				}
+				adapter.connectionRequest(ws, request);
+			});
+		} else {
+			this.addWebSocketRoute(route, null);
+		}
 	}
 }

--- a/packages/sdk/src/webHost.ts
+++ b/packages/sdk/src/webHost.ts
@@ -186,7 +186,7 @@ export class WebHost {
 	 * @param route The route at which to mount the MRE adapter.
 	 * @param adapter The adapter to add.
 	 */
-	public addAdapter(route: WebSocketRoute, adapter: Adapter) {
+	private addAdapter(route: WebSocketRoute, adapter: Adapter) {
 		if (adapter) {
 			log.info('app', `Added ${adapter.name} at route ${route}`);
 			this.addWebSocketRoute(route, (ws, request) => {


### PR DESCRIPTION
#### `WebHost.addWebSocketRoute`

This is a feature needed by the WebProjector. Added an API to WebHost to allow the registration of custom WebSocket connection handlers at different routes, e.g.:
```ts
webHost.addWebSocketRoute("/my/custom/endpoint", myCustomConnectionHandler);
```
The first parameter is the route, and can be a string or a RegExp. Second parameter is the connection handler.

#### `WebHost.addAdapter`

Building on the above capability, it was trivial to add support for servicing multiple MREs from a single WebHost, so I went ahead and added that:
```ts
const functionalTestAdapter = new MultipeerAdapter();
const helloWorldAdapter = new MultipeerAdapter();
functionalTestAdapter.onConnection((context, params) => new FunctionalTestApp(context, params));
helloWorldAdapter.onConnection((context, params) => new HelloWorldApp(context, params));
webHost.addAdapter("/functional-tests", functionalTestAdapter);
webHost.addAdapter("/hello-world", helloWorldAdapter);
```

All changes are backward compatible with existing code.

**UPDATE**: Hiding `WebHost.addAdapter` for now. There are design complications with it and serving static buffers.