### PR TITLE
[minor] Make PrimitiveDefinition a discriminated union

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,33 +4,37 @@
 	"version": "2.0.0",
 	"tasks": [
 		{
-			"label": "Build functional tests",
 			"type": "npm",
 			"script": "build",
 			"path": "packages/functional-tests/",
+			"group": "build",
 			"problemMatcher": []
 		},
 		{
 			"type": "npm",
 			"script": "build",
 			"path": "packages/sdk/",
+			"group": "build",
 			"problemMatcher": []
 		},
 		{
 			"type": "npm",
 			"script": "build",
+			"group": "build",
 			"problemMatcher": []
 		},
 		{
 			"type": "npm",
 			"script": "build",
 			"path": "packages/altspacevr-extras/",
+			"group": "build",
 			"problemMatcher": []
 		},
 		{
 			"type": "npm",
 			"script": "build",
 			"path": "packages/gltf-gen/",
+			"group": "build",
 			"problemMatcher": []
 		},
 		{

--- a/packages/functional-tests/src/app.ts
+++ b/packages/functional-tests/src/app.ts
@@ -4,7 +4,6 @@
  */
 
 import * as MRE from '@microsoft/mixed-reality-extension-sdk';
-import * as MRERPC from '@microsoft/mixed-reality-extension-sdk/built/rpc';
 
 import Menu from './menu';
 import { Test, TestFactory } from './test';
@@ -230,7 +229,7 @@ export class App {
 					}
 				},
 				collider: {
-					geometry: { shape: 'auto' }
+					geometry: { shape: MRE.ColliderType.Auto }
 				}
 			}
 		});
@@ -266,7 +265,7 @@ export class App {
 						position: { x: 0, y: -0.05, z: -1 }
 					}
 				},
-				collider: { geometry: { shape: 'auto' } }
+				collider: { geometry: { shape: MRE.ColliderType.Auto } }
 			}
 		});
 
@@ -282,7 +281,7 @@ export class App {
 						position: { x: 0, y: 1, z: 0.1 }
 					}
 				},
-				collider: { geometry: { shape: 'auto' } }
+				collider: { geometry: { shape: MRE.ColliderType.Auto } }
 			}
 		});
 
@@ -339,7 +338,7 @@ export class App {
 						position: { x: -0.65, y: 0.15, z: -1.95 }
 					}
 				},
-				collider: { geometry: { shape: 'auto' } }
+				collider: { geometry: { shape: MRE.ColliderType.Auto } }
 			}
 		});
 
@@ -381,7 +380,7 @@ export class App {
 						position: { x: 0.65, y: 0.15, z: -1.95 }
 					}
 				},
-				collider: { geometry: { shape: 'auto' } }
+				collider: { geometry: { shape: MRE.ColliderType.Auto } }
 			}
 		});
 

--- a/packages/functional-tests/src/menu.ts
+++ b/packages/functional-tests/src/menu.ts
@@ -140,7 +140,7 @@ export default class Menu {
 							}
 						}
 					},
-					collider: { geometry: { shape: 'auto' } }
+					collider: { geometry: { shape: MRE.ColliderType.Auto } }
 				}
 			});
 			this.behaviors.push(control.setBehavior(MRE.ButtonBehavior));
@@ -176,7 +176,7 @@ export default class Menu {
 						position: { x: -1 + buttonWidth / 2, y: buttonSpacing / 2, z: -0.05 }
 					}
 				},
-				collider: { geometry: { shape: 'auto' } }
+				collider: { geometry: { shape: MRE.ColliderType.Auto } }
 			}
 		});
 

--- a/packages/functional-tests/src/tests/actor-spam-test.ts
+++ b/packages/functional-tests/src/tests/actor-spam-test.ts
@@ -22,7 +22,7 @@ export default class ActorSpamTest extends Test {
 				parentId: root.id,
 				transform: { local: { position: { x: -1, y: 1.2, z: -1 } } },
 				appearance: { meshId: buttonMesh.id },
-				collider: { geometry: { shape: 'auto'} }
+				collider: { geometry: { shape: MRE.ColliderType.Auto} }
 			}
 		});
 		MRE.Actor.Create(this.app.context, {
@@ -45,7 +45,7 @@ export default class ActorSpamTest extends Test {
 				parentId: root.id,
 				transform: { local: { position: { x: -0.33, y: 1.2, z: -1 } } },
 				appearance: { meshId: buttonMesh.id },
-				collider: { geometry: { shape: 'auto'} }
+				collider: { geometry: { shape: MRE.ColliderType.Auto} }
 			}
 		});
 		MRE.Actor.Create(this.app.context, {
@@ -68,7 +68,7 @@ export default class ActorSpamTest extends Test {
 				parentId: root.id,
 				transform: { local: { position: { x: 0.33, y: 1.2, z: -1 } } },
 				appearance: { meshId: buttonMesh.id },
-				collider: { geometry: { shape: 'auto'} }
+				collider: { geometry: { shape: MRE.ColliderType.Auto} }
 			}
 		});
 		MRE.Actor.Create(this.app.context, {
@@ -91,7 +91,7 @@ export default class ActorSpamTest extends Test {
 				parentId: root.id,
 				transform: { local: { position: { x: 1, y: 1.2, z: -1 } } },
 				appearance: { meshId: buttonMesh.id },
-				collider: { geometry: { shape: 'auto'} }
+				collider: { geometry: { shape: MRE.ColliderType.Auto} }
 			}
 		});
 		MRE.Actor.Create(this.app.context, {

--- a/packages/functional-tests/src/tests/altspacevr-video-test.ts
+++ b/packages/functional-tests/src/tests/altspacevr-video-test.ts
@@ -80,7 +80,7 @@ export default class AltspaceVRVideoTest extends Test {
 						position: { x: -0.8, y: 0.2, z: 0 }
 					}
 				},
-				collider: { geometry: { shape: 'auto' } }
+				collider: { geometry: { shape: MRE.ColliderType.Auto } }
 			}
 		});
 

--- a/packages/functional-tests/src/tests/asset-preload-test.ts
+++ b/packages/functional-tests/src/tests/asset-preload-test.ts
@@ -120,7 +120,7 @@ export default class AssetPreloadTest extends Test {
 						position: { x: 0.5, y: 1, z: -1 }
 					}
 				},
-				collider: { geometry: { shape: 'auto' } }
+				collider: { geometry: { shape: MRE.ColliderType.Auto } }
 			}
 		});
 

--- a/packages/functional-tests/src/tests/asset-unload-test.ts
+++ b/packages/functional-tests/src/tests/asset-unload-test.ts
@@ -24,7 +24,7 @@ export default class AssetUnloadTest extends Test {
 						position: { y: 1, z: -1 }
 					}
 				},
-				collider: { geometry: { shape: 'sphere', radius: 0.5 } }
+				collider: { geometry: { shape: MRE.ColliderType.Sphere, radius: 0.5 } }
 			}
 		});
 		this.setup();

--- a/packages/functional-tests/src/tests/collision-layer-test.ts
+++ b/packages/functional-tests/src/tests/collision-layer-test.ts
@@ -32,7 +32,7 @@ export default class CollisionLayerTest extends Test {
 				appearance: {
 					meshId: this.assets.createBoxMesh('platformBox', 1, 0.1, 1).id
 				},
-				collider: { geometry: { shape: 'auto' }, layer: MRE.CollisionLayer.Navigation }
+				collider: { geometry: { shape: MRE.ColliderType.Auto }, layer: MRE.CollisionLayer.Navigation }
 			}
 		});
 
@@ -103,7 +103,7 @@ export default class CollisionLayerTest extends Test {
 					materialId: boxDefaultMat.id
 				},
 				collider: {
-					geometry: { shape: 'auto' },
+					geometry: { shape: MRE.ColliderType.Auto },
 					isTrigger: true,
 					layer: layer1
 				}
@@ -125,7 +125,7 @@ export default class CollisionLayerTest extends Test {
 					materialId: ballMat.id
 				},
 				collider: {
-					geometry: { shape: 'auto' },
+					geometry: { shape: MRE.ColliderType.Auto },
 					layer: layer2
 				},
 				rigidBody: {

--- a/packages/functional-tests/src/tests/grab-test.ts
+++ b/packages/functional-tests/src/tests/grab-test.ts
@@ -97,7 +97,7 @@ export default class GrabTest extends Test {
 					appearance: {
 						meshId: boxMesh.id
 					},
-					collider: { geometry: { shape: 'auto' } },
+					collider: { geometry: { shape: MRE.ColliderType.Auto } },
 					transform: { local: { position: { x: cube.x, y: 1, z: -1 } } }
 				}
 			}).grabbable = true;

--- a/packages/functional-tests/src/tests/interpolation-test.ts
+++ b/packages/functional-tests/src/tests/interpolation-test.ts
@@ -43,7 +43,7 @@ export default class InterpolationTest extends Test {
 				appearance: {
 					meshId: this.assets.createBoxMesh('box', 0.65, 0.65, 0.65).id
 				},
-				collider: { geometry: { shape: 'auto' } },
+				collider: { geometry: { shape: MRE.ColliderType.Auto } },
 				transform: {
 					local: {
 						position: { y: 1.0, z: -1.0 }

--- a/packages/functional-tests/src/tests/light-test.ts
+++ b/packages/functional-tests/src/tests/light-test.ts
@@ -141,7 +141,7 @@ export default class LightTest extends Test {
 				appearance: {
 					meshId: this.assets.createSphereMesh('sphere', 0.1).id
 				},
-				collider: { geometry: { shape: 'auto' } },
+				collider: { geometry: { shape: MRE.ColliderType.Auto } },
 				light: { type: 'spot', intensity: 5 } // Add a light component.
 			}
 		});

--- a/packages/functional-tests/src/tests/physics-sim-test.ts
+++ b/packages/functional-tests/src/tests/physics-sim-test.ts
@@ -77,7 +77,7 @@ export default class PhysicsSimTest extends Test {
 				},
 				collider: {
 					geometry: {
-						shape: 'box',
+						shape: MRE.ColliderType.Box,
 						size: { x: width, y: 0.01, z: 2 }
 					},
 					isTrigger: true
@@ -112,7 +112,7 @@ export default class PhysicsSimTest extends Test {
 						meshId: pegMesh.id,
 						materialId: this.defaultPegMat.id
 					},
-					collider: { geometry: { shape: 'auto' } }
+					collider: { geometry: { shape: MRE.ColliderType.Auto } }
 				}
 			});
 			peg.collider.onCollision('collision-enter', data => {
@@ -159,7 +159,7 @@ export default class PhysicsSimTest extends Test {
 					mass: 3,
 					constraints: [MRE.RigidBodyConstraints.FreezePositionZ]
 				},
-				collider: { geometry: { shape: 'auto' } }
+				collider: { geometry: { shape: MRE.ColliderType.Auto } }
 			}
 		});
 

--- a/packages/functional-tests/src/tests/primitives-test.ts
+++ b/packages/functional-tests/src/tests/primitives-test.ts
@@ -55,7 +55,7 @@ export default class PrimitivesTest extends Test {
 							appearance: {
 								meshId: this.assets.createBoxMesh(`box${i++}`, x, y, z).id
 							},
-							collider: { geometry: { shape: 'auto' } },
+							collider: { geometry: { shape: MRE.ColliderType.Auto } },
 							transform: {
 								local: {
 									position: { x: x * 4 - 0.8, y: y * 4 + 0., z: z * 4 - 0.5 }
@@ -73,7 +73,7 @@ export default class PrimitivesTest extends Test {
 				appearance: {
 					meshId: this.assets.createSphereMesh('sphere', 0.4, 8, 4).id
 				},
-				collider: { geometry: { shape: 'auto' } },
+				collider: { geometry: { shape: MRE.ColliderType.Auto } },
 				transform: {
 					local: {
 						position: { x: -1, y: 1, z: 0 }
@@ -89,7 +89,7 @@ export default class PrimitivesTest extends Test {
 				appearance: {
 					meshId: this.assets.createCapsuleMesh('capsule1', 0.7, 0.3, 'y', 8, 4).id
 				},
-				collider: { geometry: { shape: 'auto' } },
+				collider: { geometry: { shape: MRE.ColliderType.Auto } },
 				transform: {
 					local: {
 						position: { x: 1, y: 1, z: 0 }
@@ -105,7 +105,7 @@ export default class PrimitivesTest extends Test {
 				appearance: {
 					meshId: this.assets.createCapsuleMesh('capsule2', 0.35, 0.15, 'x', 8, 4).id
 				},
-				collider: { geometry: { shape: 'auto' } },
+				collider: { geometry: { shape: MRE.ColliderType.Auto } },
 				transform: {
 					local: {
 						position: { x: 1, y: 2.0, z: 0 }
@@ -121,7 +121,7 @@ export default class PrimitivesTest extends Test {
 				appearance: {
 					meshId: this.assets.createCapsuleMesh('capsule3', 0.7, 0.3, 'z', 8, 4).id
 				},
-				collider: { geometry: { shape: 'auto' } },
+				collider: { geometry: { shape: MRE.ColliderType.Auto } },
 				transform: {
 					local: {
 						position: { x: 1 }
@@ -137,7 +137,7 @@ export default class PrimitivesTest extends Test {
 				appearance: {
 					meshId: this.assets.createCylinderMesh('cylinder1', 1.3, 0.3, 'y', 8).id
 				},
-				collider: { geometry: { shape: 'auto' } },
+				collider: { geometry: { shape: MRE.ColliderType.Auto } },
 				transform: {
 					local: {
 						position: { x: 2, y: 1, z: 0 }
@@ -153,7 +153,7 @@ export default class PrimitivesTest extends Test {
 				appearance: {
 					meshId: this.assets.createCylinderMesh('cylinder2', 0.65, 0.15, 'x', 8).id
 				},
-				collider: { geometry: { shape: 'auto' } },
+				collider: { geometry: { shape: MRE.ColliderType.Auto } },
 				transform: {
 					local: {
 						position: { x: 2, y: 2.0, z: 0 }
@@ -169,7 +169,7 @@ export default class PrimitivesTest extends Test {
 				appearance: {
 					meshId: this.assets.createCylinderMesh('cylinder3', 1.3, 0.3, 'z', 8).id
 				},
-				collider: { geometry: { shape: 'auto' } },
+				collider: { geometry: { shape: MRE.ColliderType.Auto } },
 				transform: {
 					local: {
 						position: { x: 2 }
@@ -185,7 +185,7 @@ export default class PrimitivesTest extends Test {
 				appearance: {
 					meshId: this.assets.createPlaneMesh('plane', 1, 1, 1, 4).id
 				},
-				collider: { geometry: { shape: 'auto' } },
+				collider: { geometry: { shape: MRE.ColliderType.Auto } },
 				transform: {
 					local: {
 						position: { x: -2, y: 0.0, z: 0 }
@@ -201,7 +201,7 @@ export default class PrimitivesTest extends Test {
 				appearance: {
 					meshId: this.assets.createSphereMesh('innerSphere', -0.4, 12, 8).id
 				},
-				collider: { geometry: { shape: 'auto' } },
+				collider: { geometry: { shape: MRE.ColliderType.Auto } },
 				transform: {
 					local: {
 						position: { x: -1 }

--- a/packages/functional-tests/src/tests/prompt-test.ts
+++ b/packages/functional-tests/src/tests/prompt-test.ts
@@ -18,7 +18,7 @@ export default class PromptTest extends Test {
 				name: 'noTextButton',
 				parentId: root.id,
 				transform: { local: { position: { x: -1, y: 1, z: -1 } } },
-				collider: { geometry: { shape: 'box', size: { x: 0.5, y: 0.2, z: 0.01 } } },
+				collider: { geometry: { shape: MRE.ColliderType.Box, size: { x: 0.5, y: 0.2, z: 0.01 } } },
 				text: {
 					contents: "Click for message",
 					height: 0.1,
@@ -45,7 +45,7 @@ export default class PromptTest extends Test {
 				name: 'textButton',
 				parentId: root.id,
 				transform: { local: { position: { x: 1, y: 1, z: -1 } } },
-				collider: { geometry: { shape: 'box', size: { x: 0.5, y: 0.2, z: 0.01 } } },
+				collider: { geometry: { shape: MRE.ColliderType.Box, size: { x: 0.5, y: 0.2, z: 0.01 } } },
 				text: {
 					contents: "Click for prompt",
 					height: 0.1,

--- a/packages/functional-tests/src/tests/sound-test.ts
+++ b/packages/functional-tests/src/tests/sound-test.ts
@@ -61,7 +61,7 @@ export default class SoundTest extends Test {
 				name: 'MusicButton',
 				parentId: root.id,
 				appearance: { meshId: buttonMesh.id },
-				collider: { geometry: { shape: 'auto' } },
+				collider: { geometry: { shape: MRE.ColliderType.Auto } },
 				transform: {
 					local: {
 						position: { x: -0.8, y: 1.3, z: -0.2 }
@@ -100,7 +100,7 @@ export default class SoundTest extends Test {
 				name: 'NotesButton',
 				parentId: root.id,
 				appearance: { meshId: buttonMesh.id },
-				collider: { geometry: { shape: 'auto' } },
+				collider: { geometry: { shape: MRE.ColliderType.Auto } },
 				transform: {
 					local: {
 						position: { x: 0, y: 1.3, z: -0.2 }
@@ -133,7 +133,7 @@ export default class SoundTest extends Test {
 				name: 'DopplerButton',
 				parentId: root.id,
 				appearance: { meshId: buttonMesh.id },
-				collider: { geometry: { shape: 'auto' } },
+				collider: { geometry: { shape: MRE.ColliderType.Auto } },
 				transform: {
 					local: {
 						position: { x: 0.8, y: 1.3, z: -0.2 }
@@ -146,7 +146,7 @@ export default class SoundTest extends Test {
 				parentId: dopplerButton.id,
 				name: 'DopplerMover',
 				appearance: { meshId: this.assets.createSphereMesh('doppler', 0.15, 8, 4).id },
-				collider: { geometry: { shape: 'auto' } },
+				collider: { geometry: { shape: MRE.ColliderType.Auto } },
 				transform: {
 					local: {
 						position: { x: 0, y: 0, z: 3 }

--- a/packages/functional-tests/src/tests/user-mask-test.ts
+++ b/packages/functional-tests/src/tests/user-mask-test.ts
@@ -66,7 +66,7 @@ export default class UserMaskTest extends Test {
 					meshId: this.assets.createBoxMesh('box', 0.5, 0.5, 0.5).id,
 					materialId: red.id
 				},
-				collider: { geometry: { shape: 'auto' } },
+				collider: { geometry: { shape: MRE.ColliderType.Auto } },
 				transform: {
 					app: { position: { y: 1 } }
 				}
@@ -82,7 +82,7 @@ export default class UserMaskTest extends Test {
 					meshId: this.assets.createSphereMesh('sphere', 0.3).id,
 					materialId: blue.id
 				},
-				collider: { geometry: { shape: 'auto' } },
+				collider: { geometry: { shape: MRE.ColliderType.Auto } },
 				transform: {
 					app: { position: { y: 1 } }
 				}

--- a/packages/functional-tests/src/tests/video-test.ts
+++ b/packages/functional-tests/src/tests/video-test.ts
@@ -131,7 +131,7 @@ export default class VideoTest extends Test {
 				appearance: {
 					meshId: this.assets.createSphereMesh('sphere', 0.2).id
 				},
-				collider: { geometry: { shape: 'auto' } },
+				collider: { geometry: { shape: MRE.ColliderType.Auto } },
 				transform: {
 					local: {
 						position: { x: -0.8, y: 0.2, z: 0 }

--- a/packages/sdk/src/types/primitiveTypes.ts
+++ b/packages/sdk/src/types/primitiveTypes.ts
@@ -16,28 +16,78 @@ export enum PrimitiveShape {
 	Plane = 'plane'
 }
 
-/**
- * The size, shape, and description of a primitive.
- */
-export interface PrimitiveDefinition {
-	// TODO: Make this a discriminated union type.
-	/**
-	 * The general shape of the defined primitive.
-	 */
-	shape: PrimitiveShape;
-
+export type SpherePrimitiveDefinition = {
+	shape: PrimitiveShape.Sphere
 	/**
 	 * The bounding box size of the primitive.
 	 */
 	dimensions?: Partial<Vector3Like>;
-
 	/**
 	 * The number of horizontal or radial segments of spheres, cylinders, capsules, and planes.
 	 */
 	uSegments?: number;
-
 	/**
 	 * The number of vertical or axial segments of spheres, capsules, and planes.
 	 */
 	vSegments?: number;
-}
+};
+
+export type BoxPrimitiveDefinition = {
+	shape: PrimitiveShape.Box
+	/**
+	 * The bounding box size of the primitive.
+	 */
+	dimensions?: Partial<Vector3Like>;
+};
+
+export type CapsulePrimitiveDefinition = {
+	shape: PrimitiveShape.Capsule
+	/**
+	 * The bounding box size of the primitive.
+	 */
+	dimensions?: Partial<Vector3Like>;
+	/**
+	 * The number of horizontal or radial segments of spheres, cylinders, capsules, and planes.
+	 */
+	uSegments?: number;
+	/**
+	 * The number of vertical or axial segments of spheres, capsules, and planes.
+	 */
+	vSegments?: number;
+};
+
+export type CylinderPrimitiveDefinition = {
+	shape: PrimitiveShape.Cylinder
+	/**
+	 * The bounding box size of the primitive.
+	 */
+	dimensions?: Partial<Vector3Like>;
+	/**
+	 * The number of horizontal or radial segments of spheres, cylinders, capsules, and planes.
+	 */
+	uSegments?: number;
+};
+
+export type PlanePrimitiveDefinition = {
+	shape: PrimitiveShape.Plane
+	/**
+	 * The bounding box size of the primitive.
+	 */
+	dimensions?: Partial<Vector3Like>;
+	/**
+	 * The number of horizontal or radial segments of spheres, cylinders, capsules, and planes.
+	 */
+	uSegments?: number;
+	/**
+	 * The number of vertical or axial segments of spheres, capsules, and planes.
+	 */
+	vSegments?: number;
+};
+
+export type PrimitiveDefinition
+	= SpherePrimitiveDefinition
+	| BoxPrimitiveDefinition
+	| CapsulePrimitiveDefinition
+	| CylinderPrimitiveDefinition
+	| PlanePrimitiveDefinition
+	;

--- a/packages/sdk/src/types/runtime/actor.ts
+++ b/packages/sdk/src/types/runtime/actor.ts
@@ -339,7 +339,7 @@ export class Actor implements ActorLike, Patchable<ActorLike> {
 					meshId: mesh.id
 				},
 				collider: options.addCollider
-					? actor.collider || { geometry: { shape: 'auto' } }
+					? actor.collider || { geometry: { shape: ColliderType.Auto } }
 					: actor.collider
 			}
 		});
@@ -418,7 +418,7 @@ export class Actor implements ActorLike, Patchable<ActorLike> {
 	 */
 	// * @param collisionLayer The layer that the collider operates in.
 	public setCollider(
-		colliderType: 'sphere',
+		colliderType: ColliderType.Sphere,
 		// collisionLayer: CollisionLayer,
 		isTrigger: boolean,
 		radius?: number,
@@ -435,7 +435,7 @@ export class Actor implements ActorLike, Patchable<ActorLike> {
 	 * @param center The center of the collider, or default of the object if none is provided.
 	 */
 	public setCollider(
-		colliderType: 'box',
+		colliderType: ColliderType.Box,
 		// collisionLayer: CollisionLayer,
 		isTrigger: boolean,
 		size?: Vector3Like,
@@ -453,7 +453,7 @@ export class Actor implements ActorLike, Patchable<ActorLike> {
 	 * @param center The center of the collider, or default of the object if none is provided.
 	 */
 	public setCollider(
-		colliderType: 'capsule',
+		colliderType: ColliderType.Capsule,
 		isTrigger: boolean,
 		size?: Vector3Like,
 		center?: Vector3Like
@@ -465,7 +465,7 @@ export class Actor implements ActorLike, Patchable<ActorLike> {
 	 * @param isTrigger Whether the collider is a trigger volume or not.
 	 */
 	public setCollider(
-		colliderType: 'auto',
+		colliderType: ColliderType.Auto,
 		isTrigger: boolean
 	): void;
 
@@ -835,27 +835,27 @@ export class Actor implements ActorLike, Patchable<ActorLike> {
 		center = { x: 0, y: 0, z: 0 } as Vector3Like,
 	): ColliderGeometry {
 		switch (colliderType) {
-			case 'box':
+			case ColliderType.Box:
 				return {
-					shape: 'box',
+					shape: ColliderType.Box,
 					center,
 					size: size as Readonly<Vector3Like>
 				};
-			case 'sphere':
+			case ColliderType.Sphere:
 				return {
-					shape: 'sphere',
+					shape: ColliderType.Sphere,
 					center,
 					radius: size as number
 				};
-			case 'capsule':
+			case ColliderType.Capsule:
 				return {
-					shape: 'capsule',
+					shape: ColliderType.Capsule,
 					center,
 					size: size as Readonly<Vector3Like>
 				};
 			case 'auto':
 				return {
-					shape: 'auto'
+					shape: ColliderType.Auto
 				};
 			default:
 				log.error(null,

--- a/packages/sdk/src/types/runtime/physics/colliderGeometry.ts
+++ b/packages/sdk/src/types/runtime/physics/colliderGeometry.ts
@@ -3,36 +3,42 @@
  * Licensed under the MIT License.
  */
 
+import { ColliderType } from '.';
 import { Vector3Like } from "../../..";
 
 /**
  * Collider parameters specific to a sphere collider.
  */
-export interface SphereColliderGeometry {
-	shape: 'sphere';
+export type SphereColliderGeometry = {
+	shape: ColliderType.Sphere;
 	center?: Readonly<Vector3Like>;
 	radius?: number;
-}
+};
 
 /**
  * Collider parameters specific to a box collider
  */
-export interface BoxColliderGeometry {
-	shape: 'box';
+export type BoxColliderGeometry = {
+	shape: ColliderType.Box;
 	center?: Readonly<Vector3Like>;
 	size?: Readonly<Vector3Like>;
-}
+};
 
-export interface CapsuleColliderGeometry {
-	shape: 'capsule';
+/**
+ * Collider parameters specific to a capsule collider
+ */
+export type CapsuleColliderGeometry = {
+	shape: ColliderType.Capsule;
 	center?: Readonly<Vector3Like>;
 	size?: Readonly<Vector3Like>;
-}
+};
 
-/** A best-guess shape for the currently assigned mesh */
-export interface AutoColliderGeometry {
-	shape: 'auto';
-}
+/**
+ * A best-guess shape for the currently assigned mesh
+ */
+export type AutoColliderGeometry = {
+	shape: ColliderType.Auto;
+};
 
 /**
  * All collider parameter types.

--- a/packages/sdk/src/types/runtime/physics/colliderType.ts
+++ b/packages/sdk/src/types/runtime/physics/colliderType.ts
@@ -6,9 +6,9 @@
 /**
  * The type of the collider.
  */
-export type ColliderType
-	= 'auto'
-	| 'box'
-	| 'sphere'
-	| 'capsule'
-	;
+export enum ColliderType {
+	Auto = 'auto',
+	Box = 'box',
+	Sphere = 'sphere',
+	Capsule = 'capsule'
+}


### PR DESCRIPTION
It was bothering me that invalid fields like `uSegments` were showing up in intellisense when creating a box primitive, so I modified the type definition to discriminate by primitive type.

At the same time, I changed `ColliderType` to be an enum, to align with our newly established coding guideline that we don't use string-union types where enums would suffice.

TODO: ColliderType needs docstrings.
TODO: *PrimitiveDefinition needs better docstrings.