### PR TITLE
Sync animation updates in create calls

### DIFF
--- a/packages/sdk/src/internal/adapters/multipeer/session.ts
+++ b/packages/sdk/src/internal/adapters/multipeer/session.ts
@@ -59,6 +59,7 @@ export class Session extends EventEmitter {
 	public get animationSet() { return this._animationSet; }
 	public get animations() { return this._animationSet.values(); }
 	public get animationCreators() { return this._animationCreatorSet.values(); }
+	public get animationCreatorSet() { return this._animationCreatorSet; }
 	public get actorSet() { return this._actorSet; }
 	public get assetSet() { return this._assetSet; }
 	public get assetCreatorSet() { return this._assetCreatorSet; }


### PR DESCRIPTION
For create-animation messages, merge the latest anim state into the create call instead of sending a separate update payload.