### PR TITLE
Remove text component from physics planes

### DIFF
--- a/packages/functional-tests/src/tests/physics-bounce-test.ts
+++ b/packages/functional-tests/src/tests/physics-bounce-test.ts
@@ -7,21 +7,21 @@ import * as MRE from '@microsoft/mixed-reality-extension-sdk';
 
 import { Test } from '../test';
 
-const defaultBallColor = MRE.Color3.FromInts(220, 150, 150);
-
 export default class PhysicsBounceTest extends Test {
 	public expectedResultDescription = "Balls and boxes hit the ground and bounce.";
 	private assets: MRE.AssetContainer;
 	private interval: NodeJS.Timeout;
-	private ballboxMat: MRE.Material;
+	private materials: MRE.Material[] = [];
 	private bouncePlane: MRE.Actor;
 
 	public async run(root: MRE.Actor): Promise<boolean> {
 		this.assets = new MRE.AssetContainer(this.app.context);
 
-		this.ballboxMat = this.assets.createMaterial('ball', {
-			color: defaultBallColor
-		});
+		this.materials.push(this.assets.createMaterial('mat1', { color: MRE.Color3.FromHexString('#ff0000').toColor4() }));
+		this.materials.push(this.assets.createMaterial('mat2', { color: MRE.Color3.FromHexString('#ff7700').toColor4() }));
+		this.materials.push(this.assets.createMaterial('mat3', { color: MRE.Color3.FromHexString('#ffbd00').toColor4() }));
+		this.materials.push(this.assets.createMaterial('mat4', { color: MRE.Color3.FromHexString('#fcff00').toColor4() }));
+		this.materials.push(this.assets.createMaterial('mat5', { color: MRE.Color3.FromHexString('#abf300').toColor4() }));
 
 		this.createBouncePlane(root, 2, 1.25);
 
@@ -42,16 +42,10 @@ export default class PhysicsBounceTest extends Test {
 			actor: {
 				parentId: root.id,
 				appearance: {
-					meshId: box,
-					materialId: this.ballboxMat.id
+					meshId: box
 				},
 				transform: {
 					app: { position: { x: 0.0, y: 0.0, z: -1.0 } }
-				},
-				text: {
-					contents: `Bouncing balls and boxes`,
-					anchor: MRE.TextAnchorLocation.MiddleLeft,
-					height: .2
 				},
 				collider: {
 					geometry: { shape: MRE.ColliderType.Auto },
@@ -71,7 +65,7 @@ export default class PhysicsBounceTest extends Test {
 				parentId: root.id,
 				appearance: {
 					meshId: ballOrBoxID,
-					materialId: this.ballboxMat.id
+					materialId: this.materials[Math.floor(Math.random() * this.materials.length)].id
 				},
 				transform: {
 					local: {

--- a/packages/functional-tests/src/tests/physics-friction-test.ts
+++ b/packages/functional-tests/src/tests/physics-friction-test.ts
@@ -7,21 +7,21 @@ import * as MRE from '@microsoft/mixed-reality-extension-sdk';
 
 import { Test } from '../test';
 
-const defaultBoxColor = MRE.Color3.FromInts(220, 150, 150);
-
 export default class PhysicsFrictionTest extends Test {
 	public expectedResultDescription = "Boxes slide with different frictions.";
 	private assets: MRE.AssetContainer;
 	private interval: NodeJS.Timeout;
-	private boxMat: MRE.Material;
+	private materials: MRE.Material[] = [];
 	private slopePlane: MRE.Actor;
 
 	public async run(root: MRE.Actor): Promise<boolean> {
 		this.assets = new MRE.AssetContainer(this.app.context);
 
-		this.boxMat = this.assets.createMaterial('box', {
-			color: defaultBoxColor
-		});
+		this.materials.push(this.assets.createMaterial('mat1', { color: MRE.Color3.FromHexString('#2b7881').toColor4() }));
+		this.materials.push(this.assets.createMaterial('mat2', { color: MRE.Color3.FromHexString('#11948b').toColor4() }));
+		this.materials.push(this.assets.createMaterial('mat3', { color: MRE.Color3.FromHexString('#664a72').toColor4() }));
+		this.materials.push(this.assets.createMaterial('mat4', { color: MRE.Color3.FromHexString('#89133d').toColor4() }));
+		this.materials.push(this.assets.createMaterial('mat5', { color: MRE.Color3.FromHexString('#c7518e').toColor4() }));
 
 		this.createSlopePlane(root, 2, 1.25);
 
@@ -37,25 +37,19 @@ export default class PhysicsFrictionTest extends Test {
 	}
 
 	private createSlopePlane(root: MRE.Actor, width: number, height: number) {
-		// Create a box as a slope for sliding 
-		const box = this.assets.createBoxMesh('box', 2.5, 0.05, 2.5).id;
+		// Create a box as a slope for sliding
+		const box = this.assets.createBoxMesh('box', 2.5, 0.05, 2.5);
 		this.slopePlane = MRE.Actor.Create(this.app.context, {
 			actor: {
 				parentId: root.id,
 				appearance: {
-					meshId: box,
-					materialId: this.boxMat.id
+					meshId: box.id
 				},
 				transform: {
 					app: {
 						position: { x: 0.0, y: 0.5, z: -0.8 },
 						rotation: { x: 0.966, y: 0.0, z: 0.0, w: 0.259 }
 					} // 30 degree around Y
-				},
-				text: {
-					contents: `Boxes with different frictions`,
-					anchor: MRE.TextAnchorLocation.MiddleLeft,
-					height: .2
 				},
 				collider: {
 					geometry: { shape: MRE.ColliderType.Auto },
@@ -74,7 +68,7 @@ export default class PhysicsFrictionTest extends Test {
 				parentId: root.id,
 				appearance: {
 					meshId: boxId,
-					materialId: this.boxMat.id
+					materialId: this.materials[Math.floor(Math.random() * this.materials.length)].id
 				},
 				transform: {
 					local: {


### PR DESCRIPTION
Recent changes to the text component make it incompatible with having another mesh on the same Actor. This has been the case in Altspace for some time, but a recent change to the MRETestBed.

I also added colors to the physics shapes.