### PR TITLE
Fix sync for videostream when duration is 0 (live video/audio)

### DIFF
--- a/packages/sdk/src/internal/adapters/multipeer/rules.ts
+++ b/packages/sdk/src/internal/adapters/multipeer/rules.ts
@@ -1002,7 +1002,7 @@ export const Rules: { [id in Payloads.PayloadType]: Rule } = {
 
 					if (activeMediaInstance.message.payload.options.looping === true ||
 						activeMediaInstance.message.payload.options.paused === true ||
-						(asset === undefined || asset.duration === undefined)) {
+						(asset === undefined || asset.duration === undefined || asset.duration === 0)) {
 						// media instance current will last forever
 						activeMediaInstance.expirationTime = undefined;
 					} else {


### PR DESCRIPTION
See https://github.com/microsoft/mixed-reality-extension-sdk/issues/509#issuecomment-611472327

This is required in order to set media state (volume, stop, etc...).