### PR TITLE
Fix new prefab children of exclusive roots

### DIFF
--- a/packages/sdk/src/internal/adapters/multipeer/clientDesyncPreprocessor.ts
+++ b/packages/sdk/src/internal/adapters/multipeer/clientDesyncPreprocessor.ts
@@ -43,7 +43,12 @@ export class ClientDesyncPreprocessor implements Protocols.Middleware {
 			this.client.userId = userJoin.user.id;
 			while (this.client.userExclusiveMessages.length > 0) {
 				const queuedMsg = this.client.userExclusiveMessages.splice(0, 1)[0];
-				this.client.send(queuedMsg.message, queuedMsg.promise);
+				const rule = Rules[queuedMsg.message.payload.type] || MissingRule;
+				const forUser = rule.client.shouldSendToUser(
+					queuedMsg.message, this.client.userId, this.client.session, this.client);
+				if (forUser) {
+					this.client.send(queuedMsg.message, queuedMsg.promise);
+				}
 			}
 		}
 		return message;

--- a/packages/sdk/src/internal/adapters/multipeer/rules.ts
+++ b/packages/sdk/src/internal/adapters/multipeer/rules.ts
@@ -729,7 +729,7 @@ export const Rules: { [id in Payloads.PayloadType]: Rule } = {
 						session.cacheInitializeActorMessage({
 							payload: {
 								type: 'actor-update',
-								actor: { id: spawned.id }
+								actor: { id: spawned.id, parentId: spawned.parentId }
 							}
 						});
 					}


### PR DESCRIPTION
Bug: If you update the children of a user-exclusive prefab, those children will not be marked exclusive, even though they only exist on one client. This causes actor updates to be sent to all clients, backing up queues and breaking anything relying on `ActorManager.uponStable`.

Fix: Associate those children with the exclusive parent in the sync layer.