### PR TITLE
Adding Actor Attachment Test

### DIFF
--- a/packages/functional-tests/src/tests/actor-attachment-test.ts
+++ b/packages/functional-tests/src/tests/actor-attachment-test.ts
@@ -137,7 +137,7 @@ export default class ActorAttachmentTest extends Test {
 					contents: this.attachments[this.attachmentIndex].toString(),
 					height: 0.1,
 					anchor: MRE.TextAnchorLocation.TopCenter,
-					color: Color3.White()
+					color: MRE.Color3.White()
 				}
 			}
 		});

--- a/packages/functional-tests/src/tests/actor-attachment-test.ts
+++ b/packages/functional-tests/src/tests/actor-attachment-test.ts
@@ -5,35 +5,29 @@
  */
 import * as MRE from '@microsoft/mixed-reality-extension-sdk';
 import { Test } from '../test';
-import { Attachment, AttachPoint, Color3 } from '@microsoft/mixed-reality-extension-sdk';
-import { Box } from '@microsoft/gltf-gen';
-import { create } from 'domain';
-
-
-
 
 export default class ActorAttachmentTest extends Test {
 	public expectedResultDescription = "Actors attaching to avatar points";
 	private assets: MRE.AssetContainer;
 
 	//Limited subset of AttachmentPoints for testing
-	private attachments: AttachPoint[] =[ 
-	 'head'
-	, 'neck'
-	, 'hips'
-	, 'left-eye'
-	, 'left-foot'
-	, 'left-hand'
-	, 'right-eye'
-	, 'right-foot'
-	, 'right-hand'
+	private attachments: MRE.AttachPoint[] =[ 
+		'head',
+		'neck',
+		'hips',
+		'left-eye',
+		'left-foot',
+		'left-hand',
+		'right-eye', 
+		'right-foot', 
+		'right-hand'
 	];
 
 	//Incremented by clicking grey cube
 	private attachmentIndex = 0;
 
 	//Oblong box that gets attached to the avatar of the user running this test
-	private attachedCube : MRE.Actor;
+	private attachedCube: MRE.Actor;
 
 	//Reference to user that started this test, this user will receive attachments
 	private rootActor: MRE.Actor;
@@ -47,8 +41,9 @@ export default class ActorAttachmentTest extends Test {
 
 	//Destroy if necessary and create oblong attachment cube
 	private createCubeAttachment() {
-		if(this.attachedCube)
+		if(this.attachedCube) {
 			this.attachedCube.destroy();
+		}
 		this.attachedCube = MRE.Actor.Create(this.app.context, {
 			actor: {
 				name: 'cube1',
@@ -73,7 +68,6 @@ export default class ActorAttachmentTest extends Test {
 	public async run(root: MRE.Actor): Promise<boolean> {
 		this.rootActor = root;
 		this.assets = new MRE.AssetContainer(this.app.context);
-		const deg45 = MRE.Quaternion.FromEulerAngles(0, 0, -Math.PI / 4);
 
 		//Create Materials and actors
 		this.redMat = this.assets.createMaterial('redBall', {
@@ -123,39 +117,23 @@ export default class ActorAttachmentTest extends Test {
 
 		//Set Behaviors:
 		//createButtonBehavior switches the method of cycling attach points between re-attaching and re-creating
-		//buttonBehavior cycles the attachment point of the attachedCube and optionally destroys and re-creates the actor
+		//buttonBehavior cycles attachment point of the attachedCube and optionally destroys and re-creates the actor
 		
 		const buttonBehavior = buttonCube.setBehavior(MRE.ButtonBehavior);
 
 		const createButtonBehavior = CreateCube.setBehavior(MRE.ButtonBehavior);
 
-		buttonBehavior.onClick( () => {
-			this.attachmentIndex = (this.attachmentIndex + 1) % this.attachments.length;
-			this.attachedCube.detach();
-			
-
-			if(this.reCreateCubeTest){
-				
-				this.createCubeAttachment();
-			}
-			this.attachedCube.attach(this.user, this.attachments[this.attachmentIndex]);
-			label.text.contents = this.attachments[this.attachmentIndex].toString();
-		});
-
-		createButtonBehavior.onClick(() => {
-			this.reCreateCubeTest = !this.reCreateCubeTest;
-			if(this.reCreateCubeTest)
-				CreateCube.appearance.materialId = this.redMat.id;
-			else
-				CreateCube.appearance.materialId = this.blueMat.id;
-		});
-
 		const label = MRE.Actor.Create(this.app.context, {
 			actor: {
 				name: 'label',
 				parentId: root.id,
-				transform: { local: { position: { y: 1.5 } } },
-				text: {
+				transform: {
+					local: {
+						position: {
+							y: 1.5 
+						} 
+					}
+				}, text: {
 					contents: this.attachments[this.attachmentIndex].toString(),
 					height: 0.1,
 					anchor: MRE.TextAnchorLocation.TopCenter,
@@ -164,9 +142,30 @@ export default class ActorAttachmentTest extends Test {
 			}
 		});
 
+		buttonBehavior.onClick( () => {
+			this.attachmentIndex = (this.attachmentIndex + 1) % this.attachments.length;
+			this.attachedCube.detach();
+			
+
+			if(this.reCreateCubeTest){
+				this.createCubeAttachment();
+			}
+			this.attachedCube.attach(this.user, this.attachments[this.attachmentIndex]);
+			label.text.contents = this.attachments[this.attachmentIndex].toString();
+		});
+
+		createButtonBehavior.onClick(() => {
+			this.reCreateCubeTest = !this.reCreateCubeTest;
+			if(this.reCreateCubeTest) {
+				CreateCube.appearance.materialId = this.redMat.id;
+			} else {
+				CreateCube.appearance.materialId = this.blueMat.id;
+			}
+		});
+
 		//Starting state
 		this.createCubeAttachment();
-        this.attachedCube.attach( this.user.id, this.attachments[this.attachmentIndex] );
+		this.attachedCube.attach( this.user.id, this.attachments[this.attachmentIndex] );
 
 		await this.stoppedAsync();
 		this.attachedCube.attach(MRE.ZeroGuid, 'none');

--- a/packages/functional-tests/src/tests/actor-attachment-test.ts
+++ b/packages/functional-tests/src/tests/actor-attachment-test.ts
@@ -1,0 +1,175 @@
+
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import * as MRE from '@microsoft/mixed-reality-extension-sdk';
+import { Test } from '../test';
+import { Attachment, AttachPoint, Color3 } from '@microsoft/mixed-reality-extension-sdk';
+import { Box } from '@microsoft/gltf-gen';
+import { create } from 'domain';
+
+
+
+
+export default class ActorAttachmentTest extends Test {
+	public expectedResultDescription = "Actors attaching to avatar points";
+	private assets: MRE.AssetContainer;
+
+	//Limited subset of AttachmentPoints for testing
+	private attachments: AttachPoint[] =[ 
+	 'head'
+	, 'neck'
+	, 'hips'
+	, 'left-eye'
+	, 'left-foot'
+	, 'left-hand'
+	, 'right-eye'
+	, 'right-foot'
+	, 'right-hand'
+	];
+
+	//Incremented by clicking grey cube
+	private attachmentIndex = 0;
+
+	//Oblong box that gets attached to the avatar of the user running this test
+	private attachedCube : MRE.Actor;
+
+	//Reference to user that started this test, this user will receive attachments
+	private rootActor: MRE.Actor;
+
+	//Switch to determine if attachments are fully destroyed and remade in between changing attachment points
+	//The state is displayed by the color of the cube to the left of the attachment cycle button
+	//True = Red Cube  = attachedCube is destroyed and re-created
+	//False = Blue Cube = attachedCube is detached and attached without being destroyed
+	//Currently these produce different results in the end transform of attachedCube
+	private reCreateCubeTest = true;
+
+	//Destroy if necessary and create oblong attachment cube
+	private createCubeAttachment() {
+		if(this.attachedCube)
+			this.attachedCube.destroy();
+		this.attachedCube = MRE.Actor.Create(this.app.context, {
+			actor: {
+				name: 'cube1',
+				parentId: this.rootActor.id,
+				appearance: {
+					meshId: this.assets.createBoxMesh('smallBox', 1, 1, 1).id
+				},
+				transform: {
+					local: {
+						scale: { x: 2, y: 0.5, z: 0.5 }
+					}
+				}
+			
+			}
+		});
+	}
+
+	//Materials for displaying state of reCreateCubeTest variable
+	private redMat: MRE.Material;
+	private blueMat: MRE.Material;
+
+	public async run(root: MRE.Actor): Promise<boolean> {
+		this.rootActor = root;
+		this.assets = new MRE.AssetContainer(this.app.context);
+		const deg45 = MRE.Quaternion.FromEulerAngles(0, 0, -Math.PI / 4);
+
+		//Create Materials and actors
+		this.redMat = this.assets.createMaterial('redBall', {
+			color: MRE.Color3.Red()
+		});
+		this.blueMat = this.assets.createMaterial('blueBall', {
+			color: MRE.Color3.Blue()
+		});
+
+		const buttonCube = MRE.Actor.Create(this.app.context, {
+			actor: {
+				name: 'cube1',
+				parentId: this.rootActor.id,
+				appearance: {
+					meshId: this.assets.createBoxMesh('smallBox', 1, 1, 1).id
+				},
+				collider: { geometry: { shape: MRE.ColliderType.Box } },
+				transform: {
+					local: {
+						position: { x: 0, y: .5 },
+
+						scale: { x: 0.5, y: 0.5, z: 0.5 }
+					}
+				}
+			}
+		});
+		
+		const CreateCube = MRE.Actor.Create(this.app.context, {
+			actor: {
+				name: 'cube1',
+				parentId: this.rootActor.id,
+				appearance: {
+					meshId: this.assets.createBoxMesh('smallBox', 1, 1, 1).id,
+					materialId: this.redMat.id
+				},
+				collider: { geometry: { shape: MRE.ColliderType.Box } },
+				transform: {
+					local: {
+						position: { x: -1.0, y: .5 },
+
+						scale: { x: 0.5, y: 0.5, z: 0.5 }
+					}
+				}
+			}
+		});
+
+
+		//Set Behaviors:
+		//createButtonBehavior switches the method of cycling attach points between re-attaching and re-creating
+		//buttonBehavior cycles the attachment point of the attachedCube and optionally destroys and re-creates the actor
+		
+		const buttonBehavior = buttonCube.setBehavior(MRE.ButtonBehavior);
+
+		const createButtonBehavior = CreateCube.setBehavior(MRE.ButtonBehavior);
+
+		buttonBehavior.onClick( () => {
+			this.attachmentIndex = (this.attachmentIndex + 1) % this.attachments.length;
+			this.attachedCube.detach();
+			
+
+			if(this.reCreateCubeTest){
+				
+				this.createCubeAttachment();
+			}
+			this.attachedCube.attach(this.user, this.attachments[this.attachmentIndex]);
+			label.text.contents = this.attachments[this.attachmentIndex].toString();
+		});
+
+		createButtonBehavior.onClick(() => {
+			this.reCreateCubeTest = !this.reCreateCubeTest;
+			if(this.reCreateCubeTest)
+				CreateCube.appearance.materialId = this.redMat.id;
+			else
+				CreateCube.appearance.materialId = this.blueMat.id;
+		});
+
+		const label = MRE.Actor.Create(this.app.context, {
+			actor: {
+				name: 'label',
+				parentId: root.id,
+				transform: { local: { position: { y: 1.5 } } },
+				text: {
+					contents: this.attachments[this.attachmentIndex].toString(),
+					height: 0.1,
+					anchor: MRE.TextAnchorLocation.TopCenter,
+					color: Color3.White()
+				}
+			}
+		});
+
+		//Starting state
+		this.createCubeAttachment();
+        this.attachedCube.attach( this.user.id, this.attachments[this.attachmentIndex] );
+
+		await this.stoppedAsync();
+		this.attachedCube.attach(MRE.ZeroGuid, 'none');
+		return true;
+	}
+}

--- a/packages/functional-tests/src/tests/actor-attachment-test.ts
+++ b/packages/functional-tests/src/tests/actor-attachment-test.ts
@@ -44,12 +44,19 @@ export default class ActorAttachmentTest extends Test {
 		if(this.attachedCube) {
 			this.attachedCube.destroy();
 		}
+
+		const boxIndex = this.assets.assets.findIndex((asset)=>{
+			return asset.name === 'smallBox';
+		});
+
 		this.attachedCube = MRE.Actor.Create(this.app.context, {
 			actor: {
 				name: 'cube1',
 				parentId: this.rootActor.id,
 				appearance: {
-					meshId: this.assets.createBoxMesh('smallBox', 1, 1, 1).id
+					meshId: boxIndex === -1 ?
+						this.assets.createBoxMesh('smallBox', 1, 1, 1).id :
+						this.assets.assets[boxIndex].id
 				},
 				transform: {
 					local: {
@@ -77,12 +84,20 @@ export default class ActorAttachmentTest extends Test {
 			color: MRE.Color3.Blue()
 		});
 
+		const boxIndex = this.assets.assets.findIndex((asset) => {
+			return asset.name === 'smallBox';
+		});
+
+		const boxID = boxIndex === -1 ?
+			this.assets.createBoxMesh('smallBox', 1, 1, 1).id : 
+			this.assets.assets[boxIndex].id;
+
 		const buttonCube = MRE.Actor.Create(this.app.context, {
 			actor: {
 				name: 'cube1',
 				parentId: this.rootActor.id,
 				appearance: {
-					meshId: this.assets.createBoxMesh('smallBox', 1, 1, 1).id
+					meshId: boxID
 				},
 				collider: { geometry: { shape: MRE.ColliderType.Box } },
 				transform: {
@@ -100,7 +115,7 @@ export default class ActorAttachmentTest extends Test {
 				name: 'cube1',
 				parentId: this.rootActor.id,
 				appearance: {
-					meshId: this.assets.createBoxMesh('smallBox', 1, 1, 1).id,
+					meshId: boxID,
 					materialId: this.redMat.id
 				},
 				collider: { geometry: { shape: MRE.ColliderType.Box } },
@@ -169,6 +184,7 @@ export default class ActorAttachmentTest extends Test {
 
 		await this.stoppedAsync();
 		this.attachedCube.attach(MRE.ZeroGuid, 'none');
+		this.assets.unload();
 		return true;
 	}
 }

--- a/packages/functional-tests/src/tests/index.ts
+++ b/packages/functional-tests/src/tests/index.ts
@@ -4,6 +4,7 @@
  */
 import { TestFactory } from '../test';
 
+import ActorAttachmentTest from './actor-attachment-test';
 import ActorSpamTest from './actor-spam-test';
 import AltspaceVRLibraryTest from './altspacevr-library-test';
 import AltspaceVRVideoTest from './altspacevr-video-test';
@@ -57,6 +58,7 @@ export type FactoryMap = { [key: string]: TestFactory };
  * *** KEEP LIST SORTED ***
  */
 export const Factories = {
+	'actor-attachment': (...args) => new ActorAttachmentTest(...args),
 	'actor-spam': (...args) => new ActorSpamTest(...args),
 	'altspacevr-library': (...args) => new AltspaceVRLibraryTest(...args),
 	'altspacevr-video': (...args) => new AltspaceVRVideoTest(...args),


### PR DESCRIPTION
Adding a functional test that tests the actor attachment API

This spawns a large oblong box that attaches to the avatar of the user initiating the test, and two control cubes. The Red/Blue cube cycles between destroying and recreating the attachment when the cube is red, and re-attaching the same actor when the cube is blue. The grey box with the attachment name floating over it cycles between attachment points.

Currently, this passes when the attachment is destroyed every time, but reattaching the same actor leads to improper transforms.

I wasn't able to find anything obvious off the bat in the SDK code that could lead to this, if it makes sense I can open an issue.