### PR TITLE
Add utilities to filter Altspace users by role or event/space

### DIFF
--- a/design/user.filtering.md
+++ b/design/user.filtering.md
@@ -1,0 +1,72 @@
+User Filtering
+================
+
+It is rare that an in-market MRE will allow all users to take all actions, and it typically falls to the developer to
+filter out the users that they don't want. This operation is so common though, that adding some of this boilerplate
+to the core SDK seems reasonable. To this end, I propose the following mechanisms:
+
+
+interface UserEntryExitPoint
+------------------------------
+
+This is an interface for only the user management parts of `MRE.Context`: `onUserJoined`, `offUserJoined`, `onUserLeft`,
+and `offUserLeft`. This interface can then be applied to new classes that surface users to developers in a different
+way than Context does. One such class is `UserFilter`.
+
+
+class UserFilter
+------------------
+
+This is an abstract base class for any time you want to disregard a group of users entirely from some operation. It
+takes as constructor input a `UserEntryExitPoint` instance, and is itself a `UserEntryExitPoint`, meaning that these
+filters can be daisy-chained.
+
+Core to the concept of a filter is the actual requirement predicate. `UserFilter` has an abstract method called
+`shouldForwardUserEvent`, which takes as input a user object, and what type of event it is filtering: a user join
+or an interaction event (user-left is always tied to user-joined). It returns a boolean indicating whether the user
+passes the filter.
+
+Operationally, user filters listen for user joined/left events from the provided entry/exit point, filter those users
+by the built-in predicate, and fire their own user join/left events for users that pass. They can also filter behavior
+actions via a `filterInput` instance method, which wraps an `ActionHandler`, and only calls the handler if the
+triggering user passes the filter.
+
+
+AltspaceVR filters: moderator role and event IDs
+--------------------------------------------------
+
+In AltspaceVR, users are frequently sorted by whether they have moderator privileges in the room with the MRE. This
+is exposed to MREs by a user property named `altspacevr-roles`, which is a comma-separated list of AltspaceVR
+contextual roles, one of which is `moderator`. A new `ModeratorFilter` class in the `altspacevr-extras` NPM package
+filters users by whether they are moderators, or if a flag is passed, whether they are the *first* moderator to join
+the MRE session.
+
+Because AltspaceVR roles are context-dependent, confusing states can arise if multiple AltspaceVR contexts
+(events or spaces) are connected to the same MRE session. To avoid this, a `SingleEventFilter` class, also in
+`altspacevr-extras`, will filter out users that are not in the same context as the first user to connect to the
+session.
+
+
+Examples
+----------
+
+Filter user joins and leaves by listening to this class's events instead of the main MRE context:
+
+```js
+const filter = new ModeratorFilter(context);
+filter.onUserJoined(user => calledOnlyForModerators(user));
+filter.onUserLeft(user => calledOnlyForModerators(user));
+```
+
+Can be used to filter out input actions by moderator status:
+
+```js
+modControl.setBehavior(MRE.ButtonBehavior)
+.onClick(filter.filterInput((user, evtData) => calledOnlyForModerators(user, evtData)));
+```
+
+Can be daisy-chained with other user filters:
+
+```js
+const filter = new ModeratorFilter(new SingleEventFilter(context));
+```

--- a/packages/altspacevr-extras/src/index.ts
+++ b/packages/altspacevr-extras/src/index.ts
@@ -4,3 +4,6 @@
  */
 
 export * from './videoPlayerManager';
+export * from './userFilter';
+export * from './moderatorFilter';
+export * from './singleEventFilter';

--- a/packages/altspacevr-extras/src/index.ts
+++ b/packages/altspacevr-extras/src/index.ts
@@ -4,6 +4,5 @@
  */
 
 export * from './videoPlayerManager';
-export * from './userFilter';
 export * from './moderatorFilter';
 export * from './singleEventFilter';

--- a/packages/altspacevr-extras/src/moderatorFilter.ts
+++ b/packages/altspacevr-extras/src/moderatorFilter.ts
@@ -8,21 +8,25 @@ import { UserEntryExitPoint, UserFilter, UserInteractionType } from './userFilte
 
 /**
  * A class that filters users by whether they are moderators in the AltspaceVR room.
+ *
  * @example Filter user joins and leaves by listening to this class's events instead of the main MRE context:
- * ```ts
+ *
+ * ```js
  * const userFilter = new ModeratorFilter(context);
  * userFilter.onUserJoined(user => calledOnlyForModerators(user));
  * userFilter.onUserLeft(user => calledOnlyForModerators(user));
  * ```
  *
- * Can also be used to filter out input actions by moderator status:
- * ```ts
+ * @example Can be used to filter out input actions by moderator status:
+ *
+ * ```js
  * modControl.setBehavior(MRE.ButtonBehavior)
- * 	.onClick(userFilter.filterInput((user, evtData) => calledOnlyForModerators(user, evtData)));
+ * .onClick(userFilter.filterInput((user, evtData) => calledOnlyForModerators(user, evtData)));
  * ```
  *
- * Can be daisy-chained with other user filters:
- * ```ts
+ * @example Can be daisy-chained with other user filters:
+ *
+ * ```js
  * const filter = new ModeratorFilter(new SingleEventFilter(context));
  * ```
  */
@@ -30,7 +34,7 @@ export class ModeratorFilter extends UserFilter {
 	private singleModeratorId: MRE.Guid;
 
 	/**
-	 *
+	 * Set up the moderator filter
 	 * @param context An MRE.Context object, or another user filter instance
 	 * @param allowOnlyOneModerator If true, only the first moderator to join the session passes the filter. Useful
 	 * to prevent multi-room session attacks.

--- a/packages/altspacevr-extras/src/moderatorFilter.ts
+++ b/packages/altspacevr-extras/src/moderatorFilter.ts
@@ -1,0 +1,51 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import * as MRE from '@microsoft/mixed-reality-extension-sdk';
+import { UserEntryExitPoint, UserFilter, UserInteractionType } from './userFilter';
+
+/**
+ * A class that filters users by whether they are moderators in the AltspaceVR room.
+ * @example Filter user joins and leaves by listening to this class's events instead of the main MRE context:
+ * ```ts
+ * const userFilter = new ModeratorFilter(context);
+ * userFilter.onUserJoined(user => calledOnlyForModerators(user));
+ * userFilter.onUserLeft(user => calledOnlyForModerators(user));
+ * ```
+ *
+ * Can also be used to filter out input actions by moderator status:
+ * ```ts
+ * modControl.setBehavior(MRE.ButtonBehavior)
+ * 	.onClick(userFilter.filterInput((user, evtData) => calledOnlyForModerators(user, evtData)));
+ * ```
+ *
+ * Can be daisy-chained with other user filters:
+ * ```ts
+ * const filter = new ModeratorFilter(new SingleEventFilter(context));
+ * ```
+ */
+export class ModeratorFilter extends UserFilter {
+	private singleModeratorId: MRE.Guid;
+
+	/**
+	 *
+	 * @param context An MRE.Context object, or another user filter instance
+	 * @param allowOnlyOneModerator If true, only the first moderator to join the session passes the filter. Useful
+	 * to prevent multi-room session attacks.
+	 */
+	constructor(context: UserEntryExitPoint, private allowOnlyOneModerator = false) {
+		super(context);
+	}
+
+	protected shouldForwardUserEvent(user: MRE.User, eventType: UserInteractionType) {
+		const userRoles = new Set(user.properties['altspacevr-roles'].split(','));
+		if (this.allowOnlyOneModerator && !this.singleModeratorId && eventType === 'joined') {
+			this.singleModeratorId = user.id;
+		}
+
+		return this.allowOnlyOneModerator && this.singleModeratorId === user.id ||
+			!this.allowOnlyOneModerator && userRoles.has('moderator');
+	}
+}

--- a/packages/altspacevr-extras/src/moderatorFilter.ts
+++ b/packages/altspacevr-extras/src/moderatorFilter.ts
@@ -43,8 +43,12 @@ export class ModeratorFilter extends MRE.UserFilter {
 	}
 
 	protected shouldForwardUserEvent(user: MRE.User, eventType: MRE.UserInteractionType) {
-		const userRoles = new Set(user.properties['altspacevr-roles'].split(','));
-		if (this.allowOnlyOneModerator && !this.singleModeratorId && eventType === 'joined') {
+		const userRoles = new Set(user.properties['altspacevr-roles']?.split(','));
+		if (this.allowOnlyOneModerator &&
+			!this.singleModeratorId &&
+			eventType === 'joined' &&
+			userRoles.has('moderator')
+		) {
 			this.singleModeratorId = user.id;
 		}
 

--- a/packages/altspacevr-extras/src/moderatorFilter.ts
+++ b/packages/altspacevr-extras/src/moderatorFilter.ts
@@ -4,7 +4,6 @@
  */
 
 import * as MRE from '@microsoft/mixed-reality-extension-sdk';
-import { UserEntryExitPoint, UserFilter, UserInteractionType } from './userFilter';
 
 /**
  * A class that filters users by whether they are moderators in the AltspaceVR room.
@@ -30,7 +29,7 @@ import { UserEntryExitPoint, UserFilter, UserInteractionType } from './userFilte
  * const filter = new ModeratorFilter(new SingleEventFilter(context));
  * ```
  */
-export class ModeratorFilter extends UserFilter {
+export class ModeratorFilter extends MRE.UserFilter {
 	private singleModeratorId: MRE.Guid;
 
 	/**
@@ -39,11 +38,11 @@ export class ModeratorFilter extends UserFilter {
 	 * @param allowOnlyOneModerator If true, only the first moderator to join the session passes the filter. Useful
 	 * to prevent multi-room session attacks.
 	 */
-	constructor(context: UserEntryExitPoint, private allowOnlyOneModerator = false) {
+	constructor(context: MRE.UserEntryExitPoint, private allowOnlyOneModerator = false) {
 		super(context);
 	}
 
-	protected shouldForwardUserEvent(user: MRE.User, eventType: UserInteractionType) {
+	protected shouldForwardUserEvent(user: MRE.User, eventType: MRE.UserInteractionType) {
 		const userRoles = new Set(user.properties['altspacevr-roles'].split(','));
 		if (this.allowOnlyOneModerator && !this.singleModeratorId && eventType === 'joined') {
 			this.singleModeratorId = user.id;

--- a/packages/altspacevr-extras/src/singleEventFilter.ts
+++ b/packages/altspacevr-extras/src/singleEventFilter.ts
@@ -4,7 +4,6 @@
  */
 
 import * as MRE from '@microsoft/mixed-reality-extension-sdk';
-import { UserEntryExitPoint, UserFilter } from './userFilter';
 
 /**
  * A [[UserFilter]] that validates that all users in the session are joined to the same AltspaceVR event or space.
@@ -31,11 +30,11 @@ import { UserEntryExitPoint, UserFilter } from './userFilter';
  * const filter = new ModeratorFilter(new SingleEventFilter(context));
  * ```
  */
-export class SingleEventFilter extends UserFilter {
+export class SingleEventFilter extends MRE.UserFilter {
 	private eventOrSpaceId: string;
 
 	/** @inheritdoc */
-	constructor(context: UserEntryExitPoint) {
+	constructor(context: MRE.UserEntryExitPoint) {
 		super(context);
 	}
 

--- a/packages/altspacevr-extras/src/singleEventFilter.ts
+++ b/packages/altspacevr-extras/src/singleEventFilter.ts
@@ -9,21 +9,25 @@ import { UserEntryExitPoint, UserFilter } from './userFilter';
 /**
  * A [[UserFilter]] that validates that all users in the session are joined to the same AltspaceVR event or space.
  * Useful to prevent trolling from an unofficial room.
+ *
  * @example Filter user joins and leaves by listening to this class's events instead of the main MRE context:
- * ```ts
+ *
+ * ```js
  * const userFilter = new SingleEventFilter(context);
  * userFilter.onUserJoined(user => calledOnlyForValidatedUsers(user));
  * userFilter.onUserLeft(user => calledOnlyForValidatedUsers(user));
  * ```
  *
- * Can also be used to filter out input actions:
- * ```ts
- * modControl.setBehavior(MRE.ButtonBehavior)
- * 	.onClick(userFilter.filterInput((user, evtData) => calledOnlyForValidatedUsers(user, evtData)));
+ * @example Can be used to filter out input actions:
+ *
+ * ```js
+ * button.setBehavior(MRE.ButtonBehavior)
+ * .onClick(userFilter.filterInput((user, evtData) => calledOnlyForValidatedUsers(user, evtData)));
  * ```
  *
- * Can be daisy-chained with other user filters:
- * ```ts
+ * @example Can be daisy-chained with other user filters:
+ *
+ * ```js
  * const filter = new ModeratorFilter(new SingleEventFilter(context));
  * ```
  */

--- a/packages/altspacevr-extras/src/singleEventFilter.ts
+++ b/packages/altspacevr-extras/src/singleEventFilter.ts
@@ -1,0 +1,46 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import * as MRE from '@microsoft/mixed-reality-extension-sdk';
+import { UserEntryExitPoint, UserFilter } from './userFilter';
+
+/**
+ * A [[UserFilter]] that validates that all users in the session are joined to the same AltspaceVR event or space.
+ * Useful to prevent trolling from an unofficial room.
+ * @example Filter user joins and leaves by listening to this class's events instead of the main MRE context:
+ * ```ts
+ * const userFilter = new SingleEventFilter(context);
+ * userFilter.onUserJoined(user => calledOnlyForValidatedUsers(user));
+ * userFilter.onUserLeft(user => calledOnlyForValidatedUsers(user));
+ * ```
+ *
+ * Can also be used to filter out input actions:
+ * ```ts
+ * modControl.setBehavior(MRE.ButtonBehavior)
+ * 	.onClick(userFilter.filterInput((user, evtData) => calledOnlyForValidatedUsers(user, evtData)));
+ * ```
+ *
+ * Can be daisy-chained with other user filters:
+ * ```ts
+ * const filter = new ModeratorFilter(new SingleEventFilter(context));
+ * ```
+ */
+export class SingleEventFilter extends UserFilter {
+	private eventOrSpaceId: string;
+
+	/** @inheritdoc */
+	constructor(context: UserEntryExitPoint) {
+		super(context);
+	}
+
+	protected shouldForwardUserEvent(user: MRE.User) {
+		const userEventOrSpaceId = user.properties['altspacevr-event-id'] ?? user.properties['altspacevr-space-id'];
+		if (!this.eventOrSpaceId && userEventOrSpaceId) {
+			this.eventOrSpaceId = userEventOrSpaceId;
+		}
+
+		return this.eventOrSpaceId && userEventOrSpaceId === this.eventOrSpaceId;
+	}
+}

--- a/packages/altspacevr-extras/src/userFilter.ts
+++ b/packages/altspacevr-extras/src/userFilter.ts
@@ -1,0 +1,88 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import * as MRE from '@microsoft/mixed-reality-extension-sdk';
+
+/** A callback that handles when a user joins or leaves the MRE session */
+export type UserEntryExitCallback = (user: MRE.User) => void;
+
+/** An event type for [[UserFilter.shouldForwardUserEvent]] */
+export type UserInteractionType = 'joined' | 'input';
+
+/** A class that has user joined/left callback hooks. Applies to MRE.Context, and also [[UserFilter]]s. */
+export interface UserEntryExitPoint {
+	onUserJoined(callback: UserEntryExitCallback): void;
+	onUserLeft(callback: UserEntryExitCallback): void;
+	offUserJoined(callback: UserEntryExitCallback): void;
+	offUserLeft(callback: UserEntryExitCallback): void;
+}
+
+/** Base class for classes that filter out users from MRE awareness */
+export abstract class UserFilter implements UserEntryExitPoint {
+	private joinedCallbacks = new Set<UserEntryExitCallback>();
+	private leftCallbacks = new Set<UserEntryExitCallback>();
+
+	/** The set of IDs of joined users */
+	protected joinedUsers = new Set<MRE.Guid>();
+
+	/**
+	 * Set up the user filter
+	 * @param context An MRE.Context object, or another user filter instance
+	 */
+	constructor(protected context: UserEntryExitPoint) {
+		this.context.onUserJoined(u => this.onUpstreamUserJoined(u));
+		this.context.onUserLeft(u => this.onUpstreamUserLeft(u));
+	}
+
+	/** Register a callback that will be called when a user that passes the filter joins the MRE session */
+	public onUserJoined(callback: UserEntryExitCallback) {
+		this.joinedCallbacks.add(callback);
+	}
+
+	/** Deregister an [[onUserJoined]] callback */
+	public offUserJoined(callback: UserEntryExitCallback) {
+		this.joinedCallbacks.delete(callback);
+	}
+
+	/** Register a callback that will be called when a user that passes the filter leaves the MRE session */
+	public onUserLeft(callback: UserEntryExitCallback) {
+		this.leftCallbacks.add(callback);
+	}
+
+	/** Deregister an [[onUserLeft]] callback */
+	public offUserLeft(callback: UserEntryExitCallback) {
+		this.leftCallbacks.delete(callback);
+	}
+
+	/** Process an input event only from users that pass the filter */
+	public filterInput(eventHandler: MRE.ActionHandler<any>): MRE.ActionHandler<any> {
+		return (user: MRE.User, data: any) => {
+			if (this.shouldForwardUserEvent(user, 'input')) {
+				eventHandler(user, data);
+			}
+		};
+	}
+
+	/** Evaluates whether a user should be accepted by the filter for the given event type */
+	protected abstract shouldForwardUserEvent(user: MRE.User, type: UserInteractionType): boolean;
+
+	private onUpstreamUserJoined(user: MRE.User) {
+		if (this.shouldForwardUserEvent(user, 'joined')) {
+			this.joinedUsers.add(user.id);
+			for (const cb of this.joinedCallbacks) {
+				cb(user);
+			}
+		}
+	}
+
+	private onUpstreamUserLeft(user: MRE.User) {
+		if (this.joinedUsers.has(user.id)) {
+			this.joinedUsers.delete(user.id);
+			for (const cb of this.leftCallbacks) {
+				cb(user);
+			}
+		}
+	}
+}

--- a/packages/functional-tests/src/tests/altspacevr-user-filter-test.ts
+++ b/packages/functional-tests/src/tests/altspacevr-user-filter-test.ts
@@ -1,0 +1,70 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import * as MRE from '@microsoft/mixed-reality-extension-sdk';
+import { ModeratorFilter, SingleEventFilter } from '@microsoft/mixed-reality-extension-altspacevr-extras';
+import { Test } from '../test';
+
+export default class AltspaceVRUserFilterTest extends Test {
+	public expectedResultDescription = "Only moderators can press the button";
+
+	private assets: MRE.AssetContainer;
+	private filter: MRE.UserFilter;
+	private modList: MRE.Actor;
+	private modButton: MRE.Actor;
+
+	public async run(root: MRE.Actor): Promise<boolean> {
+		this.assets = new MRE.AssetContainer(this.app.context);
+		this.filter = new ModeratorFilter(new SingleEventFilter(this.app.context));
+
+		this.modList = MRE.Actor.Create(this.app.context, { actor: {
+			name: "moderatorList",
+			parentId: root.id,
+			transform: { local: {
+				position: { x: -0.5, y: 1.6, z: -1 }
+			}},
+			text: {
+				contents: "Moderators:\n" + this.filter.users.map(u => u.name).join('\n'),
+				anchor: MRE.TextAnchorLocation.TopCenter,
+				height: 0.1
+			}
+		}});
+
+		this.filter.onUserJoined(() => this.updateModList());
+		this.filter.onUserLeft(() => this.updateModList());
+
+		const modMat = this.assets.createMaterial("buttonMat", {
+			color: { r: 0.5, b: 0.5, g: 0.5, a: 1 }
+		});
+
+		this.modButton = MRE.Actor.Create(this.app.context, { actor: {
+			name: "moderatorButton",
+			parentId: root.id,
+			transform: { local: {
+				position: { x: 0.5, y: 1, z: -1 }
+			}},
+			appearance: {
+				meshId: this.assets.createBoxMesh("moderatorButton", 0.2, 0.2, 0.01).id,
+				materialId: modMat.id
+			},
+			collider: { geometry: { shape: MRE.ColliderType.Auto } }
+		}});
+
+		this.modButton.setBehavior(MRE.ButtonBehavior)
+			.onButton('pressed', this.filter.filterInput(() => modMat.color.set(1, 1, 1, 1)))
+			.onButton('released', this.filter.filterInput(() => modMat.color.set(0.5, 0.5, 0.5, 1)));
+
+		await this.stoppedAsync();
+		return true;
+	}
+
+	private updateModList() {
+		this.modList.text.contents = "Moderators:\n" + this.filter.users.map(u => u.name).join('\n');
+	}
+
+	public unload() {
+		this.assets.unload();
+	}
+}

--- a/packages/functional-tests/src/tests/index.ts
+++ b/packages/functional-tests/src/tests/index.ts
@@ -6,6 +6,7 @@ import { TestFactory } from '../test';
 
 import ActorSpamTest from './actor-spam-test';
 import AltspaceVRLibraryTest from './altspacevr-library-test';
+import AltspaceVRUserFilterTest from './altspacevr-user-filter-test';
 import AltspaceVRVideoTest from './altspacevr-video-test';
 import AnimationBlendTest from './animation-blend-test';
 import AnimationDynamicTest from './animation-dynamic-test';
@@ -59,6 +60,7 @@ export type FactoryMap = { [key: string]: TestFactory };
 export const Factories = {
 	'actor-spam': (...args) => new ActorSpamTest(...args),
 	'altspacevr-library': (...args) => new AltspaceVRLibraryTest(...args),
+	'altspacevr-user-filter': (...args) => new AltspaceVRUserFilterTest(...args),
 	'altspacevr-video': (...args) => new AltspaceVRVideoTest(...args),
 	'animation-blend': (...args) => new AnimationBlendTest(...args),
 	'animation-dynamic': (...args) => new AnimationDynamicTest(...args),

--- a/packages/sdk/src/core/context.ts
+++ b/packages/sdk/src/core/context.ts
@@ -4,7 +4,7 @@
  */
 
 import events from 'events';
-import { Actor, Guid, newGuid, RPC, RPCChannels, User, } from '..';
+import { Actor, Guid, newGuid, RPC, RPCChannels, User, UserEntryExitPoint } from '..';
 import { Connection, NullConnection, Payloads } from '../internal';
 import { ContextInternal } from './contextInternal';
 
@@ -20,7 +20,7 @@ export interface ContextSettings {
  * Container for an application session. The Context contains all application state for a session of your application.
  * This includes Actors, Users, Assets, and other state.
  */
-export class Context {
+export class Context implements UserEntryExitPoint {
 	private _internal: ContextInternal;
 	/** @hidden */
 	public get internal() { return this._internal; }

--- a/packages/sdk/src/util/index.ts
+++ b/packages/sdk/src/util/index.ts
@@ -9,4 +9,5 @@ export * from './guid';
 export * from './log';
 export * from './planarGridLayout';
 export * from './readonlyMap';
+export * from './userFilter';
 export * from './webHost';

--- a/packages/sdk/src/util/userFilter.ts
+++ b/packages/sdk/src/util/userFilter.ts
@@ -3,15 +3,15 @@
  * Licensed under the MIT License.
  */
 
-import * as MRE from '@microsoft/mixed-reality-extension-sdk';
+import { ActionHandler, Guid, User } from '..';
 
 /** A callback that handles when a user joins or leaves the MRE session */
-export type UserEntryExitCallback = (user: MRE.User) => void;
+export type UserEntryExitCallback = (user: User) => void;
 
 /** An event type for [[UserFilter.shouldForwardUserEvent]] */
 export type UserInteractionType = 'joined' | 'input';
 
-/** A class that has user joined/left callback hooks. Applies to MRE.Context, and also [[UserFilter]]s. */
+/** A class that has user joined/left callback hooks. Applies to [[Context]], and also [[UserFilter]]s. */
 export interface UserEntryExitPoint {
 	onUserJoined(callback: UserEntryExitCallback): void;
 	onUserLeft(callback: UserEntryExitCallback): void;
@@ -25,7 +25,7 @@ export abstract class UserFilter implements UserEntryExitPoint {
 	private leftCallbacks = new Set<UserEntryExitCallback>();
 
 	/** The set of IDs of joined users */
-	protected joinedUsers = new Set<MRE.Guid>();
+	protected joinedUsers = new Set<Guid>();
 
 	/**
 	 * Set up the user filter
@@ -57,8 +57,8 @@ export abstract class UserFilter implements UserEntryExitPoint {
 	}
 
 	/** Process an input event only from users that pass the filter */
-	public filterInput(eventHandler: MRE.ActionHandler<any>): MRE.ActionHandler<any> {
-		return (user: MRE.User, data: any) => {
+	public filterInput(eventHandler: ActionHandler<any>): ActionHandler<any> {
+		return (user: User, data: any) => {
 			if (this.shouldForwardUserEvent(user, 'input')) {
 				eventHandler(user, data);
 			}
@@ -66,9 +66,9 @@ export abstract class UserFilter implements UserEntryExitPoint {
 	}
 
 	/** Evaluates whether a user should be accepted by the filter for the given event type */
-	protected abstract shouldForwardUserEvent(user: MRE.User, type: UserInteractionType): boolean;
+	protected abstract shouldForwardUserEvent(user: User, type: UserInteractionType): boolean;
 
-	private onUpstreamUserJoined(user: MRE.User) {
+	private onUpstreamUserJoined(user: User) {
 		if (this.shouldForwardUserEvent(user, 'joined')) {
 			this.joinedUsers.add(user.id);
 			for (const cb of this.joinedCallbacks) {
@@ -77,7 +77,7 @@ export abstract class UserFilter implements UserEntryExitPoint {
 		}
 	}
 
-	private onUpstreamUserLeft(user: MRE.User) {
+	private onUpstreamUserLeft(user: User) {
 		if (this.joinedUsers.has(user.id)) {
 			this.joinedUsers.delete(user.id);
 			for (const cb of this.leftCallbacks) {

--- a/packages/sdk/src/util/userFilter.ts
+++ b/packages/sdk/src/util/userFilter.ts
@@ -68,7 +68,7 @@ export abstract class UserFilter implements UserEntryExitPoint {
 	}
 
 	/** Process an input event only from users that pass the filter */
-	public filterInput<T = null>(eventHandler: ActionHandler<T>): ActionHandler<T> {
+	public filterInput<T = void>(eventHandler: ActionHandler<T>): ActionHandler<T> {
 		return (user: User, data: T) => {
 			if (this.shouldForwardUserEvent(user, 'input')) {
 				eventHandler(user, data);


### PR DESCRIPTION
* Add a general-purpose API for writing classes that filter user joins, leaves, and interactions.
* Implement a filter that accepts AltspaceVR moderators.
* Implement a filter that accepts users that are in the same event or space as the first user to join.