### PR TITLE
Disallow additional properties in manifests

### DIFF
--- a/packages/sdk/src/util/manifestSchema.json
+++ b/packages/sdk/src/util/manifestSchema.json
@@ -1,6 +1,7 @@
 {
 	"$schema": "https://json-schema.org/draft-04/schema#",
 	"type": "object",
+	"additionalProperties": false,
 	"properties": {
 		"name": { "type": "string" },
 		"description": { "type": "string" },


### PR DESCRIPTION
Catch manifest misspellings and other errors by disallowing unexpected properties. The error message will look like this:

```
2020-08-10T17:56:36.429Z app Node: v12.17.0
2020-08-10T17:56:36.437Z app @microsoft/mixed-reality-extension-sdk: v0.20.0
2020-08-10T17:56:36.446Z app App manifest "C:\Users\stvergen\Projects\mre-sdk\packages\functional-tests\public\manifest.json" is not valid:
instance additionalProperty "requiredPermissions" exists in instance when not allowed
2020-08-10T17:56:36.460Z app Multi-peer Adapter listening on {"address":"::","family":"IPv6","port":3901}
2020-08-10T17:56:36.461Z app baseUrl: http://127.0.0.1:3901
2020-08-10T17:56:36.461Z app baseDir: C:\Users\stvergen\Projects\mre-sdk\packages\functional-tests\public
2020-08-10T17:56:36.461Z app No MRE manifest provided, and no permissions requested! For this MRE to use protected features, provide an MRE manifest at "C:\Users\stvergen\Projects\mre-sdk\packages\functional-tests\public\manifest.json", or pass a permissions list into the WebHost constructor.
```