### PR TITLE
Actors with orphaned ownership will properly update upon new authoritative user

### DIFF
--- a/packages/sdk/src/core/contextInternal.ts
+++ b/packages/sdk/src/core/contextInternal.ts
@@ -68,14 +68,12 @@ export class ContextInternal {
 
 	public onSetAuthoritative = (userId: Guid) => {
 		this._rigidBodyOrphanSet.forEach( 
-			(value) => {
-				if (value === this._rigidBodyDefaultOwner) {
-					const actor = this.actorSet.get(value);
-					actor.owner = userId;
-
-					this._rigidBodyOwnerMap.set(value, userId);
-				}
-			})
+			(actorId) => {
+				const actor = this.actorSet.get(actorId);
+				actor.owner = userId;
+				this._rigidBodyOwnerMap.set(actorId, userId);
+			}
+		)
 		this._rigidBodyOrphanSet.clear();
 		this._rigidBodyDefaultOwner = userId;
 	};
@@ -531,22 +529,23 @@ export class ContextInternal {
 			this.context.emitter.emit('user-left', user);
 
 			if (userId !== this._rigidBodyDefaultOwner) {
-				this._rigidBodyOwnerMap.forEach( (value, key) => {
-					if (value === userId) {
-						const actor = this.actorSet.get(key);
-						actor.owner = this._rigidBodyDefaultOwner;
-						this._rigidBodyOwnerMap.set(key, this._rigidBodyDefaultOwner);
+				this._rigidBodyOwnerMap.forEach( 
+					(ownerId, actorId) => {
+						if (ownerId === userId) {
+							const actor = this.actorSet.get(actorId);
+							actor.owner = this._rigidBodyDefaultOwner;
+							this._rigidBodyOwnerMap.set(actorId, this._rigidBodyDefaultOwner);
+						}
 					}
-				})
+				)
 			} else {
 				this._rigidBodyOwnerMap.forEach( 
-					(value, key) => {
-						if (value === userId) {
-							const actor = this.actorSet.get(key);
-							actor.owner = this._rigidBodyDefaultOwner;
-							this._rigidBodyOrphanSet.add(key);
+					(ownerId, actorId) => {
+						if (ownerId === userId) {
+							this._rigidBodyOrphanSet.add(actorId);
 						}
-					})
+					}
+				)
 			}
 		}
 	}


### PR DESCRIPTION
From my testing, `_rigidBodyDefaultOwner` has already changed to the new authoritative user before `userLeft()` is called. This means that the actors owned by the user that just left changes ownership to the new authoritative user without the actor being orphaned. 

However, if  an actor were orphaned, it wouldn't properly update ownership when a new authoritative user is assigned. This fix ensures that ownership is properly changed.

Related issue #742

This PR is required for PR #744