### PR TITLE
Newly created actor without ownership will properly receive default ownership once authoritative user is assigned

### DIFF
--- a/packages/sdk/src/core/contextInternal.ts
+++ b/packages/sdk/src/core/contextInternal.ts
@@ -453,11 +453,15 @@ export class ContextInternal {
 			actor.copy(sactor);
 			if (isNewActor) {
 				newActorIds.push(actor.id);
-				if (actor.rigidBody) {	
+				if (actor.rigidBody) {
 					if (!actor.owner) {
-						actor.owner = this._rigidBodyDefaultOwner;
+						if (!this._rigidBodyDefaultOwner) {
+							this._rigidBodyOrphanSet.add(actor.id);
+						} else {
+							actor.owner = this._rigidBodyDefaultOwner;
+							this._rigidBodyOwnerMap.set(actor.id, actor.owner);
+						}
 					}
-					this._rigidBodyOwnerMap.set(actor.id, actor.owner);
 				}
 			}
 		});


### PR DESCRIPTION
If an actor - without the owner property being defined - is created directly after the `onStarted()` event, it will receive a default owner of `undefined` since the authoritative user hasn't been assigned yet. This update will add the actor to `_rigidBodyOrphanSet` so that once the authoritative user is assigned, the actor will properly receive the default owner.

Related issues #732 #742
Requires PR #743