### PR TITLE
Fix for transform subscriptions when actor is an attachment

### DIFF
--- a/packages/sdk/src/internal/adapters/multipeer/rules.ts
+++ b/packages/sdk/src/internal/adapters/multipeer/rules.ts
@@ -305,8 +305,10 @@ export const Rules: { [id in Payloads.PayloadType]: Rule } = {
 				message: Message<Payloads.ActorCorrection>
 			) => {
 				const syncActor = session.actorSet.get(message.payload.actorId);
-				if (syncActor && ((client.authoritative && !syncActor.grabbedBy)
-					|| (syncActor.grabbedBy === client.id))) {
+				const attachment = syncActor.initialization.message.payload.actor.attachment;
+				if (syncActor && ((client.authoritative && !syncActor.grabbedBy) ||
+					(syncActor.grabbedBy === client.id) || 
+                    (attachment && attachment.userId === client.userId))) {
 					const correctionPayload = message.payload;
 
 					// Synthesize an actor update message and add in the transform from the correction payload.
@@ -402,8 +404,10 @@ export const Rules: { [id in Payloads.PayloadType]: Rule } = {
 				message: Message<Payloads.ActorUpdate>
 			) => {
 				const syncActor = session.actorSet.get(message.payload.actor.id);
+				const attachment = syncActor.initialization.message.payload.actor.attachment;
 				if (syncActor && ((client.authoritative && !syncActor.grabbedBy) ||
-					(syncActor.grabbedBy === client.id))) {
+					(syncActor.grabbedBy === client.id) || 
+                    (attachment && attachment.userId === client.userId))) {
 					// Merge the update into the existing actor.
 					session.cacheActorUpdateMessage(message);
 

--- a/packages/sdk/src/internal/adapters/multipeer/rules.ts
+++ b/packages/sdk/src/internal/adapters/multipeer/rules.ts
@@ -305,10 +305,10 @@ export const Rules: { [id in Payloads.PayloadType]: Rule } = {
 				message: Message<Payloads.ActorCorrection>
 			) => {
 				const syncActor = session.actorSet.get(message.payload.actorId);
-				const attachment = syncActor.initialization.message.payload.actor.attachment;
+				const attached = syncActor?.initialization.message.payload.actor.attachment;
 				if (syncActor && ((client.authoritative && !syncActor.grabbedBy) ||
 					(syncActor.grabbedBy === client.id) || 
-                    (attachment && attachment.userId === client.userId))) {
+                    (attached && attached.userId === client.userId))) {
 					const correctionPayload = message.payload;
 
 					// Synthesize an actor update message and add in the transform from the correction payload.
@@ -404,10 +404,10 @@ export const Rules: { [id in Payloads.PayloadType]: Rule } = {
 				message: Message<Payloads.ActorUpdate>
 			) => {
 				const syncActor = session.actorSet.get(message.payload.actor.id);
-				const attachment = syncActor.initialization.message.payload.actor.attachment;
+				const attached = syncActor?.initialization.message.payload.actor.attachment;
 				if (syncActor && ((client.authoritative && !syncActor.grabbedBy) ||
 					(syncActor.grabbedBy === client.id) || 
-                    (attachment && attachment.userId === client.userId))) {
+                    (attached && attached.userId === client.userId))) {
 					// Merge the update into the existing actor.
 					session.cacheActorUpdateMessage(message);
 


### PR DESCRIPTION
This fix allows transform subscriptions to pass to the app when actor is an attachment.

Issue #739

This PR is similar to #740 but for the correct branch (red).