### PR TITLE
Fixes several memory leaks associated with destroying an actor

### DIFF
--- a/packages/sdk/src/actor/actor.ts
+++ b/packages/sdk/src/actor/actor.ts
@@ -202,8 +202,10 @@ export class Actor implements ActorLike, Patchable<ActorLike> {
 	 * Destroys the collider.
 	 */
 	public clearCollider(): void {
-		unobserve(this._collider)
-		this._collider = null;
+		if (this._collider) {
+			unobserve(this._collider)
+			this._collider = null;
+		}
 	}
 
 	/**

--- a/packages/sdk/src/actor/actor.ts
+++ b/packages/sdk/src/actor/actor.ts
@@ -199,6 +199,14 @@ export class Actor implements ActorLike, Patchable<ActorLike> {
 	 */
 
 	/**
+	 * Destroys the collider.
+	 */
+	public clearCollider(): void {
+		unobserve(this._collider)
+		this._collider = null;
+	}
+
+	/**
 	 * Creates a new, empty actor without geometry.
 	 * @param context The SDK context object.
 	 * @param options.actor The initial state of the actor.
@@ -417,6 +425,7 @@ export class Actor implements ActorLike, Patchable<ActorLike> {
 	 * based on the size of the currently assigned mesh (loading meshes are not considered).
 	 * If no mesh is assigned, defaults to 0.5.
 	 * @param center The center of the collider, or default of the object if none is provided.
+	 * @param layer Controls what the assigned actors will collide with.
 	 */
 	// * @param collisionLayer The layer that the collider operates in.
 	public setCollider(
@@ -424,7 +433,8 @@ export class Actor implements ActorLike, Patchable<ActorLike> {
 		// collisionLayer: CollisionLayer,
 		isTrigger: boolean,
 		radius?: number,
-		center?: Vector3Like
+		center?: Vector3Like,
+		layer?: CollisionLayer
 	): void;
 
 	/**
@@ -435,13 +445,14 @@ export class Actor implements ActorLike, Patchable<ActorLike> {
 	 * based on the currently assigned mesh (loading meshes are not considered).
 	 * If no mesh is assigned, defaults to (1,1,1).
 	 * @param center The center of the collider, or default of the object if none is provided.
+	 * @param layer Controls what the assigned actors will collide with.
 	 */
 	public setCollider(
 		colliderType: ColliderType.Box,
-		// collisionLayer: CollisionLayer,
 		isTrigger: boolean,
 		size?: Vector3Like,
-		center?: Vector3Like
+		center?: Vector3Like,
+		layer?: CollisionLayer
 	): void;
 
 	/**
@@ -453,37 +464,48 @@ export class Actor implements ActorLike, Patchable<ActorLike> {
 	 * If omitted, a best-guess size is chosen based on the currently assigned mesh
 	 * (loading meshes are not considered). If no mesh is assigned, defaults to (1, 1, 1).
 	 * @param center The center of the collider, or default of the object if none is provided.
+	 * @param layer Controls what the assigned actors will collide with.
 	 */
 	public setCollider(
 		colliderType: ColliderType.Capsule,
 		isTrigger: boolean,
 		size?: Vector3Like,
-		center?: Vector3Like
+		center?: Vector3Like,
+		layer?: CollisionLayer
 	): void;
 
 	/**
 	 * Adds a collider whose shape is determined by the current mesh.
 	 * @param colliderType Type of the collider to enable.
 	 * @param isTrigger Whether the collider is a trigger volume or not.
+	 * @param size The dimensions of the collider, with the largest component of the vector
+	 * being the primary axis and height of the capsule (including end caps), and the smallest the diameter.
+	 * If omitted, a best-guess size is chosen based on the currently assigned mesh
+	 * (loading meshes are not considered). If no mesh is assigned, defaults to (1, 1, 1).
+	 * @param center The center of the collider, or default of the object if none is provided.
+	 * @param layer Controls what the assigned actors will collide with.
 	 */
 	public setCollider(
 		colliderType: ColliderType.Auto,
-		isTrigger: boolean
+		isTrigger: boolean,
+		size?: Vector3Like,
+		center?: Vector3Like,
+		layer?: CollisionLayer
 	): void;
 
 	public setCollider(
 		colliderType: ColliderType,
-		// collisionLayer: CollisionLayer,
 		isTrigger: boolean,
 		size?: number | Vector3Like,
-		center = { x: 0, y: 0, z: 0 } as Vector3Like
+		center = { x: 0, y: 0, z: 0 } as Vector3Like,
+		layer = CollisionLayer.Default,
 	): void {
 		const colliderGeometry = this.generateColliderGeometry(colliderType, size, center);
 		if (colliderGeometry) {
 			this._setCollider({
 				enabled: true,
 				isTrigger,
-				// collisionLayer,
+				layer,
 				geometry: colliderGeometry
 			} as ColliderLike);
 		}

--- a/packages/sdk/src/actor/physics/colliderInternal.ts
+++ b/packages/sdk/src/actor/physics/colliderInternal.ts
@@ -49,6 +49,9 @@ export class ColliderInternal {
 		for (const event of other._eventHandlers.eventNames()) {
 			for (const handler of other._eventHandlers.listeners(event)) {
 				this._eventHandlers.on(event, handler as (...args: any[]) => void);
+
+				//Remove other event handlers during copy
+				other._eventHandlers.off(event, handler as (...args: any[]) => void)
 			}
 		}
 	}

--- a/packages/sdk/src/core/contextInternal.ts
+++ b/packages/sdk/src/core/contextInternal.ts
@@ -625,6 +625,12 @@ export class ContextInternal {
 			this.localDestroyActor(child);
 		});
 
+		//Remove animations
+		for (const anim of actor.targetingAnimations.values()) {
+			anim.data.clearReference(anim)
+			anim.data.breakReference(anim);
+		}
+
 		//Remove the collider
 		if (actor.collider) {
 			actor.clearCollider();
@@ -633,11 +639,13 @@ export class ContextInternal {
 		//Remove mesh reference
 		if (actor.appearance.mesh) {
 			actor.appearance.mesh.clearReference(actor)
+			actor.appearance.mesh.breakReference(actor);
 		}
 
 		//Remove material reference
 		if (actor.appearance.material) {
 			actor.appearance.material.clearReference(actor)
+			actor.appearance.material.breakReference(actor);
 		}
 
 		// Remove actor from _actors

--- a/packages/sdk/src/core/contextInternal.ts
+++ b/packages/sdk/src/core/contextInternal.ts
@@ -451,8 +451,6 @@ export class ContextInternal {
 			const actor = isNewActor ? Actor.alloc(this.context, sactor.id) : this.actorSet.get(sactor.id);
 			this.actorSet.set(sactor.id, actor);
 
-			//TODO - Fix memory leak that occurs when instantiating an actor with a collider. Use setCollider instead.
-			//Collider is attached to actor via actor.copy(sactor), but it creates a memory leak.
 			actor.copy(sactor);
 			if (isNewActor) {
 				newActorIds.push(actor.id);


### PR DESCRIPTION
Summary of changes:

Creates a public method on actor that unobserves the collider and breaks the reference to the collider.
Removes mesh references to the actor to be destroyed
Removes material references to the actor to be destroyed
Added the ability to set the Collider layer using setCollider.
    - Setting the collider when instantiating an actor creates a memory leak due the manner in which the collider is attached to the actor.  Left a TODO to resolve this, but did not want to introduce any code breaking changes.

Unobserves 'other' collider listeners when copying to a new collider.
