### PR TITLE
targeting red branch

### DIFF
--- a/packages/sdk/src/actor/actor.ts
+++ b/packages/sdk/src/actor/actor.ts
@@ -432,7 +432,6 @@ export class Actor implements ActorLike, Patchable<ActorLike> {
 	 * based on the size of the currently assigned mesh (loading meshes are not considered).
 	 * If no mesh is assigned, defaults to 0.5.
 	 * @param center The center of the collider, or default of the object if none is provided.
-	 * @param layer Controls what the assigned actors will collide with.
 	 */
 	// * @param collisionLayer The layer that the collider operates in.
 	public setCollider(
@@ -441,7 +440,6 @@ export class Actor implements ActorLike, Patchable<ActorLike> {
 		isTrigger: boolean,
 		radius?: number,
 		center?: Vector3Like,
-		layer?: CollisionLayer
 	): void;
 
 	/**
@@ -452,14 +450,12 @@ export class Actor implements ActorLike, Patchable<ActorLike> {
 	 * based on the currently assigned mesh (loading meshes are not considered).
 	 * If no mesh is assigned, defaults to (1,1,1).
 	 * @param center The center of the collider, or default of the object if none is provided.
-	 * @param layer Controls what the assigned actors will collide with.
 	 */
 	public setCollider(
 		colliderType: ColliderType.Box,
 		isTrigger: boolean,
 		size?: Vector3Like,
 		center?: Vector3Like,
-		layer?: CollisionLayer
 	): void;
 
 	/**
@@ -471,30 +467,22 @@ export class Actor implements ActorLike, Patchable<ActorLike> {
 	 * If omitted, a best-guess size is chosen based on the currently assigned mesh
 	 * (loading meshes are not considered). If no mesh is assigned, defaults to (1, 1, 1).
 	 * @param center The center of the collider, or default of the object if none is provided.
-	 * @param layer Controls what the assigned actors will collide with.
 	 */
 	public setCollider(
 		colliderType: ColliderType.Capsule,
 		isTrigger: boolean,
 		size?: Vector3Like,
 		center?: Vector3Like,
-		layer?: CollisionLayer,
 	): void;
 
 	/**
 	 * Adds a collider whose shape is determined by the current mesh.
 	 * @param colliderType Type of the collider to enable.
 	 * @param isTrigger Whether the collider is a trigger volume or not.
-	 * @param size Ignored for ColliderType Auto.
-	 * @param center Ignored for ColliderType Auto.
-	 * @param layer Controls what the assigned actors will collide with.
 	 */
 	public setCollider(
 		colliderType: ColliderType.Auto,
 		isTrigger: boolean,
-		size?: Vector3Like,
-		center?: Vector3Like,
-		layer?: CollisionLayer
 	): void;
 
 	public setCollider(

--- a/packages/sdk/src/actor/actor.ts
+++ b/packages/sdk/src/actor/actor.ts
@@ -490,12 +490,10 @@ export class Actor implements ActorLike, Patchable<ActorLike> {
 		isTrigger: boolean,
 		size?: number | Vector3Like,
 		center = { x: 0, y: 0, z: 0 } as Vector3Like,
-		layer = CollisionLayer.Default,
 	): void {
 		this._setCollider({
 			enabled: true,
 			isTrigger,
-			layer,
 			geometry: {shape: colliderType, size, center}
 		} as ColliderLike);
 	}

--- a/packages/sdk/src/actor/physics/colliderInternal.ts
+++ b/packages/sdk/src/actor/physics/colliderInternal.ts
@@ -49,6 +49,9 @@ export class ColliderInternal {
 		for (const event of other._eventHandlers.eventNames()) {
 			for (const handler of other._eventHandlers.listeners(event)) {
 				this._eventHandlers.on(event, handler as (...args: any[]) => void);
+
+				//Remove other event handlers during copy
+				other._eventHandlers.off(event, handler as (...args: any[]) => void)
 			}
 		}
 	}

--- a/packages/sdk/src/animation/animation.ts
+++ b/packages/sdk/src/animation/animation.ts
@@ -187,6 +187,7 @@ export class Animation implements AnimationLike, Patchable<AnimationLike> {
 	public get targetActors() {
 		return this.targetIds.map(id => this.context.actor(id)).filter(a => !!a);
 	}
+
 	/** The list of animations targeted by this animation. */
 	/* public get targetAnimations() {
 		return this.targetIds.map(id => this.context.animation(id)).filter(a => !!a);
@@ -313,6 +314,11 @@ export class Animation implements AnimationLike, Patchable<AnimationLike> {
 	/** Destroy this animation. */
 	public delete() {
 		this.context.internal.destroyAnimation(this.id);
+	}
+
+	/** Remove target id */
+	public removeTargetId(id: Guid) {
+		this._targetIds = this._targetIds.filter(_id => _id !== id);
 	}
 
 	/** @hidden */

--- a/packages/sdk/src/core/contextInternal.ts
+++ b/packages/sdk/src/core/contextInternal.ts
@@ -67,7 +67,7 @@ export class ContextInternal {
 	}
 
 	public onSetAuthoritative = (userId: Guid) => {
-		this._rigidBodyOrphanSet.forEach( 
+		this._rigidBodyOrphanSet.forEach(
 			(actorId) => {
 				const actor = this.actorSet.get(actorId);
 				actor.owner = userId;
@@ -312,7 +312,7 @@ export class ContextInternal {
 			execution.on('protocol.update-user', this.updateUser.bind(this));
 			execution.on('protocol.perform-action', this.performAction.bind(this));
 			execution.on('protocol.physicsbridge-update-transforms', this.updatePhysicsBridgeTransforms.bind(this));
-			execution.on('protocol.physicsbridge-server-transforms-upload', 
+			execution.on('protocol.physicsbridge-server-transforms-upload',
 				this.updatePhysicsServerTransformsUpload.bind(this));
 			execution.on('protocol.receive-rpc', this.receiveRPC.bind(this));
 			execution.on('protocol.collision-event-raised', this.collisionEventRaised.bind(this));
@@ -533,7 +533,7 @@ export class ContextInternal {
 			this.context.emitter.emit('user-left', user);
 
 			if (userId !== this._rigidBodyDefaultOwner) {
-				this._rigidBodyOwnerMap.forEach( 
+				this._rigidBodyOwnerMap.forEach(
 					(ownerId, actorId) => {
 						if (ownerId === userId) {
 							const actor = this.actorSet.get(actorId);
@@ -543,7 +543,7 @@ export class ContextInternal {
 					}
 				)
 			} else {
-				this._rigidBodyOwnerMap.forEach( 
+				this._rigidBodyOwnerMap.forEach(
 					(ownerId, actorId) => {
 						if (ownerId === userId) {
 							this._rigidBodyOrphanSet.add(actorId);
@@ -626,6 +626,29 @@ export class ContextInternal {
 		(actor.children || []).forEach(child => {
 			this.localDestroyActor(child);
 		});
+
+		//Remove animations
+		for (const anim of actor.targetingAnimations.values()) {
+			anim.data.clearReference(anim)
+			anim.data.breakReference(anim);
+		}
+
+		//Remove the collider
+		if (actor.collider) {
+			actor.clearCollider();
+		}
+
+		//Remove mesh reference
+		if (actor.appearance.mesh) {
+			actor.appearance.mesh.clearReference(actor)
+			actor.appearance.mesh.breakReference(actor);
+		}
+
+		//Remove material reference
+		if (actor.appearance.material) {
+			actor.appearance.material.clearReference(actor)
+			actor.appearance.material.breakReference(actor);
+		}
 
 		// Remove actor from _actors
 		this.actorSet.delete(actor.id);

--- a/packages/sdk/src/core/contextInternal.ts
+++ b/packages/sdk/src/core/contextInternal.ts
@@ -629,8 +629,7 @@ export class ContextInternal {
 
 		//Remove animations
 		for (const anim of actor.targetingAnimations.values()) {
-			anim.data.clearReference(anim)
-			anim.data.breakReference(anim);
+			anim.removeTargetId(actor.id)
 		}
 
 		//Remove the collider


### PR DESCRIPTION
Summary of changes:

-Removes animation references of the actor to be destroyed.

-Creates a public method on actor that destroys a collider (unobserves the collider and breaks the reference to the collider).

-Removes the collider of the actor to be destroyed.

-Removes mesh references of the actor to be destroyed.

-Removes material references of the actor to be destroyed.

-Added the ability to set the Collider layer using setCollider.

-Resolves a memory leak associated with creating an actor containing a collider, via actor.copy(). Setting the collider via setCollider() does not create a memory leak. To avoid calling generateColliderGeometry multiple times, I deferred the call of generateColliderGeometry() in setCollider into _setCollider(). This creates a fresh collider geometry whether the collider is created via setCollider() or during an actor instantiation, via actor.copy(). The fresh collider geometry is then re-attached to collider, but breaks the references causing the memory leak.

-Unobserves 'other' collider listeners when copying to a new collider.